### PR TITLE
fix DSE paddle mapping mistake and touchpad grid wrong calculation

### DIFF
--- a/JoyShockMapper/src/SDLWrapper.cpp
+++ b/JoyShockMapper/src/SDLWrapper.cpp
@@ -484,11 +484,12 @@ public:
 			break;
 		case JS_TYPE_DS:
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC1) ? 1 << JSOFFSET_MIC : 0;
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_TOUCHPAD) ? 1 << JSOFFSET_CAPTURE : 0;
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1) ? 1 << JSOFFSET_SR : 0;
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_LEFT_PADDLE1) ? 1 << JSOFFSET_SL : 0;
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2) ? 1 << JSOFFSET_FNR : 0;
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_LEFT_PADDLE2) ? 1 << JSOFFSET_FNL : 0;
-			// Intentional fall through to the next case
+			break;
 		case JS_TYPE_DS4:
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_TOUCHPAD) ? 1 << JSOFFSET_CAPTURE : 0;
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1) ? 1 << JSOFFSET_SL : 0;

--- a/JoyShockMapper/src/main.cpp
+++ b/JoyShockMapper/src/main.cpp
@@ -220,6 +220,7 @@ void touchCallback(int jcHandle, TOUCH_STATE newState, TOUCH_STATE prevState, fl
 		int index0 = -1, index1 = -1;
 		if (point0.isDown())
 		{
+			point0.posY += 1e-6f;
 			float row = ceilf(point0.posY * grid_size.value().y()) - 1.f;
 			float col = ceilf(point0.posX * grid_size.value().x()) - 1.f;
 			// COUT << "I should be in button " << row << " " << col << '\n';


### PR DESCRIPTION
This fixes a regression introduced in v3.6.0 where pressing a DualSense Edge right paddle and function button triggers both left and right inputs.

Cause: The JS_TYPE_DS case falls through to JS_TYPE_DS4 and maps the same SDL paddle buttons twice after the SDL mapping refactor.

Fix: Add a break after JS_TYPE_DS to prevent duplicate paddle mappings.