### PR TITLE
Switch to an installer and add auto-update functionality

### DIFF
--- a/JSM_GUI/jsm-gui-app/electron-builder.json5
+++ b/JSM_GUI/jsm-gui-app/electron-builder.json5
@@ -24,6 +24,7 @@
   },
   "win": {
     "icon": "public/gyro-icon.ico",
+    "artifactName": "JoyShockMapper-Custom-Curve-Setup-${version}.${ext}",
     "target": [
       {
         "target": "nsis",

--- a/JSM_GUI/jsm-gui-app/electron-builder.json5
+++ b/JSM_GUI/jsm-gui-app/electron-builder.json5
@@ -17,22 +17,27 @@
       "to": "bin"
     }
   ],
+  "publish": {
+    "provider": "github",
+    "owner": "evan1mclean",
+    "repo": "JSM_custom_curve"
+  },
   "win": {
     "icon": "public/gyro-icon.ico",
     "target": [
       {
-        "target": "zip",
+        "target": "nsis",
         "arch": [
           "x64"
         ]
       }
-    ],
-    "artifactName": "${productName}.zip"
+    ]
   },
   "nsis": {
     "oneClick": false,
     "perMachine": false,
     "allowToChangeInstallationDirectory": true,
-    "deleteAppDataOnUninstall": false
+    "deleteAppDataOnUninstall": false,
+    "createDesktopShortcut": true
   }
 }

--- a/JSM_GUI/jsm-gui-app/electron/main.ts
+++ b/JSM_GUI/jsm-gui-app/electron/main.ts
@@ -34,6 +34,8 @@ let latestTelemetryPacket: Record<string, unknown> | null = null
 let jsmProcess: ChildProcess | null = null
 let calibrationTimer: NodeJS.Timeout | null = null
 let calibrationSecondsSetting = 5
+let pendingUpdateVersion: string | null = null
+let updateReadyToInstall = false
 
 type BackendChoice = 'SDL' | 'legacy'
 const TELEMETRY_PORT = 8974
@@ -572,6 +574,12 @@ async function createWindow() {
     if (latestTelemetryPacket) {
       win?.webContents.send('telemetry-sample', latestTelemetryPacket)
     }
+    if (pendingUpdateVersion) {
+      win?.webContents.send('update-available', pendingUpdateVersion)
+    }
+    if (updateReadyToInstall) {
+      win?.webContents.send('update-downloaded')
+    }
   })
 
   if (VITE_DEV_SERVER_URL) {
@@ -626,6 +634,7 @@ app.whenReady().then(async () => {
   autoUpdater.checkForUpdates().catch(err => console.error('Update check failed', err))
 
   autoUpdater.on('update-available', (info) => {
+    pendingUpdateVersion = info.version
     win?.webContents.send('update-available', info.version)
   })
 
@@ -634,6 +643,8 @@ app.whenReady().then(async () => {
   })
 
   autoUpdater.on('update-downloaded', () => {
+    pendingUpdateVersion = null
+    updateReadyToInstall = true
     win?.webContents.send('update-downloaded')
   })
 })

--- a/JSM_GUI/jsm-gui-app/electron/main.ts
+++ b/JSM_GUI/jsm-gui-app/electron/main.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, ipcMain, shell } from 'electron'
+import { autoUpdater } from 'electron-updater'
 import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 import fs from 'node:fs/promises'
@@ -202,6 +203,13 @@ async function setStartupProfilePath(relativePath: string) {
 
 async function ensureStartupCalibrationBlock() {
   let relative = await getStartupProfilePath()
+  if (relative) {
+    try {
+      await fs.access(absoluteProfilePath(relative))
+    } catch {
+      relative = null
+    }
+  }
   if (!relative) {
     relative = DEFAULT_PROFILE_RELATIVE
   }
@@ -611,6 +619,16 @@ app.whenReady().then(async () => {
   setTimeout(() => {
     launchJoyShockMapper(calibrationSecondsSetting).catch(err => console.error('Auto-launch failed', err))
   }, 500)
+
+  autoUpdater.checkForUpdates().catch(err => console.error('Update check failed', err))
+
+  autoUpdater.on('update-available', (info) => {
+    win?.webContents.send('update-available', info.version)
+  })
+
+  autoUpdater.on('update-downloaded', () => {
+    win?.webContents.send('update-downloaded')
+  })
 })
 
 app.on('will-quit', () => {
@@ -634,6 +652,7 @@ const normalizeRelativeProfilePath = (input?: string | null) => {
 }
 
 ipcMain.handle('open-external', (_event, url: string) => shell.openExternal(url))
+ipcMain.handle('install-update', () => autoUpdater.quitAndInstall())
 
 ipcMain.handle('get-backend-choice', async () => backendChoice)
 

--- a/JSM_GUI/jsm-gui-app/electron/main.ts
+++ b/JSM_GUI/jsm-gui-app/electron/main.ts
@@ -629,7 +629,6 @@ app.whenReady().then(async () => {
     launchJoyShockMapper(calibrationSecondsSetting).catch(err => console.error('Auto-launch failed', err))
   }, 500)
 
-  autoUpdater.allowPrerelease = true
   autoUpdater.autoDownload = false
   autoUpdater.checkForUpdates().catch(err => console.error('Update check failed', err))
 

--- a/JSM_GUI/jsm-gui-app/electron/main.ts
+++ b/JSM_GUI/jsm-gui-app/electron/main.ts
@@ -612,6 +612,7 @@ app.on('activate', () => {
 
 app.whenReady().then(async () => {
   await loadBackendChoice()
+  await restoreUserDataAfterUpdate()
   await ensureRequiredFiles()
   await loadCalibrationSecondsFromStartup()
   startTelemetryListener()
@@ -620,10 +621,16 @@ app.whenReady().then(async () => {
     launchJoyShockMapper(calibrationSecondsSetting).catch(err => console.error('Auto-launch failed', err))
   }, 500)
 
+  autoUpdater.allowPrerelease = true
+  autoUpdater.autoDownload = false
   autoUpdater.checkForUpdates().catch(err => console.error('Update check failed', err))
 
   autoUpdater.on('update-available', (info) => {
     win?.webContents.send('update-available', info.version)
+  })
+
+  autoUpdater.on('download-progress', (progress) => {
+    win?.webContents.send('update-download-progress', Math.floor(progress.percent))
   })
 
   autoUpdater.on('update-downloaded', () => {
@@ -651,8 +658,70 @@ const normalizeRelativeProfilePath = (input?: string | null) => {
   return normalized
 }
 
+async function backupUserDataForUpdate() {
+  const backupDir = path.join(DATA_DIR, 'update-backup')
+  const backupProfilesDir = path.join(backupDir, 'profiles-library')
+  try {
+    await fs.mkdir(backupProfilesDir, { recursive: true })
+    const profiles = await fs.readdir(PROFILE_LIBRARY_DIR).catch(() => [])
+    for (const file of profiles) {
+      if (file.toLowerCase().endsWith('.txt')) {
+        await fs.copyFile(
+          path.join(PROFILE_LIBRARY_DIR, file),
+          path.join(backupProfilesDir, file)
+        )
+      }
+    }
+    try {
+      await fs.copyFile(STARTUP_FILE, path.join(backupDir, 'OnStartUp.txt'))
+    } catch {
+      // OnStartUp.txt may not exist yet — not a fatal error
+    }
+    await writeLog('User data backed up for update')
+  } catch (err) {
+    await writeLog(`Failed to backup user data for update: ${String(err)}`)
+    throw err
+  }
+}
+
+async function restoreUserDataAfterUpdate() {
+  const backupDir = path.join(DATA_DIR, 'update-backup')
+  try {
+    await fs.access(backupDir)
+  } catch {
+    return // No backup present — normal startup
+  }
+  try {
+    const backupProfilesDir = path.join(backupDir, 'profiles-library')
+    await fs.mkdir(PROFILE_LIBRARY_DIR, { recursive: true })
+    const files = await fs.readdir(backupProfilesDir).catch(() => [])
+    for (const file of files) {
+      if (file.toLowerCase().endsWith('.txt')) {
+        await fs.copyFile(
+          path.join(backupProfilesDir, file),
+          path.join(PROFILE_LIBRARY_DIR, file)
+        )
+      }
+    }
+    try {
+      await fs.copyFile(path.join(backupDir, 'OnStartUp.txt'), STARTUP_FILE)
+    } catch {
+      // Backed-up OnStartUp.txt may not exist — ensureStartupCalibrationBlock will recreate it
+    }
+    await fs.rm(backupDir, { recursive: true, force: true })
+    await writeLog('User data restored after update')
+  } catch (err) {
+    await writeLog(`Failed to restore user data after update: ${String(err)}`)
+    // Don't throw — proceed with startup even if restore partially fails
+  }
+}
+
 ipcMain.handle('open-external', (_event, url: string) => shell.openExternal(url))
-ipcMain.handle('install-update', () => autoUpdater.quitAndInstall())
+ipcMain.handle('download-update', () => autoUpdater.downloadUpdate())
+ipcMain.handle('install-update', async () => {
+  await backupUserDataForUpdate()
+  autoUpdater.quitAndInstall(true, true)
+})
 
 ipcMain.handle('get-backend-choice', async () => backendChoice)
 

--- a/JSM_GUI/jsm-gui-app/electron/preload.ts
+++ b/JSM_GUI/jsm-gui-app/electron/preload.ts
@@ -48,6 +48,28 @@ ipcRenderer.on('calibration-status', (_event, payload) => {
   })
 })
 
+const updateAvailableListeners = new Set<(version: string) => void>()
+ipcRenderer.on('update-available', (_event, version: string) => {
+  updateAvailableListeners.forEach(listener => {
+    try {
+      listener(version)
+    } catch (err) {
+      console.error('[updater] update-available listener failed', err)
+    }
+  })
+})
+
+const updateDownloadedListeners = new Set<() => void>()
+ipcRenderer.on('update-downloaded', () => {
+  updateDownloadedListeners.forEach(listener => {
+    try {
+      listener()
+    } catch (err) {
+      console.error('[updater] update-downloaded listener failed', err)
+    }
+  })
+})
+
 const telemetryAPI = {
   onSample: (callback: (payload: unknown) => void) => {
     if (typeof callback !== 'function') {
@@ -67,5 +89,20 @@ contextBridge.exposeInMainWorld('electronAPI', {
     calibrationListeners.add(callback)
     return () => calibrationListeners.delete(callback)
   },
+  onUpdateAvailable: (callback: (version: string) => void) => {
+    if (typeof callback !== 'function') {
+      return () => {}
+    }
+    updateAvailableListeners.add(callback)
+    return () => updateAvailableListeners.delete(callback)
+  },
+  onUpdateDownloaded: (callback: () => void) => {
+    if (typeof callback !== 'function') {
+      return () => {}
+    }
+    updateDownloadedListeners.add(callback)
+    return () => updateDownloadedListeners.delete(callback)
+  },
+  installUpdate: () => ipcRenderer.invoke('install-update'),
 })
 contextBridge.exposeInMainWorld('telemetry', telemetryAPI)

--- a/JSM_GUI/jsm-gui-app/electron/preload.ts
+++ b/JSM_GUI/jsm-gui-app/electron/preload.ts
@@ -70,6 +70,17 @@ ipcRenderer.on('update-downloaded', () => {
   })
 })
 
+const updateProgressListeners = new Set<(percent: number) => void>()
+ipcRenderer.on('update-download-progress', (_event, percent: number) => {
+  updateProgressListeners.forEach(listener => {
+    try {
+      listener(percent)
+    } catch (err) {
+      console.error('[updater] download-progress listener failed', err)
+    }
+  })
+})
+
 const telemetryAPI = {
   onSample: (callback: (payload: unknown) => void) => {
     if (typeof callback !== 'function') {
@@ -103,6 +114,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
     updateDownloadedListeners.add(callback)
     return () => updateDownloadedListeners.delete(callback)
   },
+  onUpdateDownloadProgress: (callback: (percent: number) => void) => {
+    if (typeof callback !== 'function') {
+      return () => {}
+    }
+    updateProgressListeners.add(callback)
+    return () => updateProgressListeners.delete(callback)
+  },
+  downloadUpdate: () => ipcRenderer.invoke('download-update'),
   installUpdate: () => ipcRenderer.invoke('install-update'),
 })
 contextBridge.exposeInMainWorld('telemetry', telemetryAPI)

--- a/JSM_GUI/jsm-gui-app/package-lock.json
+++ b/JSM_GUI/jsm-gui-app/package-lock.json
@@ -8,6 +8,7 @@
       "name": "jsm-gui-app",
       "version": "1.0.1",
       "dependencies": {
+        "electron-updater": "^6.8.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-markdown": "^10.1.0"
@@ -2581,7 +2582,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-union": {
@@ -3897,6 +3897,70 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/electron-updater": {
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.3.tgz",
+      "integrity": "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.5.1",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/builder-util-runtime": {
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
+      "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-updater/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-updater/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -4831,7 +4895,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -5347,7 +5410,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5435,7 +5497,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lazystream": {
@@ -5535,11 +5596,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
@@ -7171,7 +7245,6 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
       "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
-      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/scheduler": {
@@ -7187,7 +7260,6 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7616,6 +7688,12 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
       "license": "MIT"
     },
     "node_modules/tinyglobby": {

--- a/JSM_GUI/jsm-gui-app/package.json
+++ b/JSM_GUI/jsm-gui-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jsm-gui-app",
   "private": true,
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "JoyShockMapper Custom Curve GUI with bundled JSM and custom accel curves",
   "author": "Evan McLean",
   "type": "module",
@@ -12,6 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "electron-updater": "^6.8.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0"

--- a/JSM_GUI/jsm-gui-app/src/App.tsx
+++ b/JSM_GUI/jsm-gui-app/src/App.tsx
@@ -1,4 +1,5 @@
 import './App.css'
+import { version as APP_VERSION } from '../package.json'
 import sideNavStyles from './components/SideNav.module.css'
 import topBarStyles from './components/TopBar.module.css'
 import { ThemeToggle } from './components/ThemeToggle'
@@ -741,6 +742,7 @@ function App() {
         <div className={sideNavStyles.navFooter}>
           <HelpNavButton primaryTab={primaryTab} setPrimaryTab={setPrimaryTab} />
           <ThemeToggle />
+          <div className={sideNavStyles.navVersion}>v{APP_VERSION}</div>
         </div>
       </aside>
       {/* Narrow-width sticky header */}

--- a/JSM_GUI/jsm-gui-app/src/App.tsx
+++ b/JSM_GUI/jsm-gui-app/src/App.tsx
@@ -19,6 +19,7 @@ import { useProfileLibrary } from './hooks/useProfileLibrary'
 import { useKeymapConfig } from './hooks/useKeymapConfig'
 import { useCalibration } from './hooks/useCalibration'
 import { ToastHost } from './components/ToastHost'
+import { UpdateBanner } from './components/UpdateBanner'
 import { RwcGuideModal } from './components/RwcGuideModal'
 import { updateKeymapEntry } from './utils/keymap'
 
@@ -732,6 +733,7 @@ function App() {
   return (
     <div className="app-shell">
       <ToastHost />
+      <UpdateBanner />
       {/* Desktop sidebar */}
       <aside className={sideNavStyles.sideNav}>
         <div className={sideNavStyles.navBrand}>JSM Custom Curve</div>
@@ -923,7 +925,7 @@ function App() {
       )}
       <RwcGuideModal
         isOpen={isRwcGuideModalOpen}
-        inGameSens={sensitivity.inGameSens ?? ''}
+        inGameSens={String(sensitivity.inGameSens ?? '')}
         onClose={() => setIsRwcGuideModalOpen(false)}
         onApplyRwc={(rwc) => {
           const baseText = finalizePendingValues ? finalizePendingValues() : configText
@@ -946,7 +948,6 @@ function App() {
               hasPendingChanges={hasPendingChanges}
               isCalibrating={isCalibrating}
               profileApplied={configText === appliedConfig}
-              statusMessage={statusMessage}
               onImportProfile={handleImportProfile}
               libraryProfiles={libraryProfiles}
               libraryLoading={isLibraryLoading}

--- a/JSM_GUI/jsm-gui-app/src/components/Misc.module.css
+++ b/JSM_GUI/jsm-gui-app/src/components/Misc.module.css
@@ -156,3 +156,27 @@
     transform: translateY(-6px);
   }
 }
+
+.updateBanner {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  background: var(--toast-success-bg);
+  border: 1px solid var(--toast-success-border);
+  color: var(--toast-success-text);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+  z-index: 9999;
+  white-space: nowrap;
+}
+
+.updateBannerActions {
+  display: flex;
+  gap: 0.5rem;
+}

--- a/JSM_GUI/jsm-gui-app/src/components/SideNav.module.css
+++ b/JSM_GUI/jsm-gui-app/src/components/SideNav.module.css
@@ -45,6 +45,13 @@
   gap: 0.6rem;
 }
 
+.navVersion {
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  text-align: center;
+  opacity: 0.6;
+}
+
 .navItem {
   text-align: left;
   border-radius: 10px;

--- a/JSM_GUI/jsm-gui-app/src/components/UpdateBanner.tsx
+++ b/JSM_GUI/jsm-gui-app/src/components/UpdateBanner.tsx
@@ -3,17 +3,22 @@ import styles from './Misc.module.css'
 
 type UpdateState =
   | { phase: 'idle' }
-  | { phase: 'downloading'; version: string }
+  | { phase: 'available'; version: string }
+  | { phase: 'downloading' }
   | { phase: 'ready' }
 
 export function UpdateBanner() {
   const [update, setUpdate] = useState<UpdateState>({ phase: 'idle' })
   const [dismissed, setDismissed] = useState(false)
+  const [progress, setProgress] = useState(0)
 
   useEffect(() => {
     const removeAvailable = window.electronAPI?.onUpdateAvailable?.((version) => {
-      setUpdate({ phase: 'downloading', version })
+      setUpdate({ phase: 'available', version })
       setDismissed(false)
+    })
+    const removeProgress = window.electronAPI?.onUpdateDownloadProgress?.((percent) => {
+      setProgress(percent)
     })
     const removeDownloaded = window.electronAPI?.onUpdateDownloaded?.(() => {
       setUpdate({ phase: 'ready' })
@@ -21,6 +26,7 @@ export function UpdateBanner() {
     })
     return () => {
       removeAvailable?.()
+      removeProgress?.()
       removeDownloaded?.()
     }
   }, [])
@@ -29,8 +35,32 @@ export function UpdateBanner() {
 
   return (
     <div className={styles.updateBanner}>
+      {update.phase === 'available' && (
+        <>
+          <span>Update v{update.version} available.</span>
+          <div className={styles.updateBannerActions}>
+            <button
+              type="button"
+              className="secondary-btn"
+              onClick={() => {
+                setUpdate({ phase: 'downloading' })
+                window.electronAPI?.downloadUpdate?.()
+              }}
+            >
+              Download Now
+            </button>
+            <button
+              type="button"
+              className="secondary-btn"
+              onClick={() => setDismissed(true)}
+            >
+              Later
+            </button>
+          </div>
+        </>
+      )}
       {update.phase === 'downloading' && (
-        <span>Update v{update.version} available — downloading in the background…</span>
+        <span>Downloading update… {progress}%</span>
       )}
       {update.phase === 'ready' && (
         <>

--- a/JSM_GUI/jsm-gui-app/src/components/UpdateBanner.tsx
+++ b/JSM_GUI/jsm-gui-app/src/components/UpdateBanner.tsx
@@ -22,7 +22,6 @@ export function UpdateBanner() {
     })
     const removeDownloaded = window.electronAPI?.onUpdateDownloaded?.(() => {
       setUpdate({ phase: 'ready' })
-      setDismissed(false)
     })
     return () => {
       removeAvailable?.()
@@ -65,22 +64,13 @@ export function UpdateBanner() {
       {update.phase === 'ready' && (
         <>
           <span>Update ready to install.</span>
-          <div className={styles.updateBannerActions}>
-            <button
-              type="button"
-              className="secondary-btn"
-              onClick={() => window.electronAPI?.installUpdate?.()}
-            >
-              Restart Now
-            </button>
-            <button
-              type="button"
-              className="secondary-btn"
-              onClick={() => setDismissed(true)}
-            >
-              Later
-            </button>
-          </div>
+          <button
+            type="button"
+            className="secondary-btn"
+            onClick={() => window.electronAPI?.installUpdate?.()}
+          >
+            Restart Now
+          </button>
         </>
       )}
     </div>

--- a/JSM_GUI/jsm-gui-app/src/components/UpdateBanner.tsx
+++ b/JSM_GUI/jsm-gui-app/src/components/UpdateBanner.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react'
+import styles from './Misc.module.css'
+
+type UpdateState =
+  | { phase: 'idle' }
+  | { phase: 'downloading'; version: string }
+  | { phase: 'ready' }
+
+export function UpdateBanner() {
+  const [update, setUpdate] = useState<UpdateState>({ phase: 'idle' })
+  const [dismissed, setDismissed] = useState(false)
+
+  useEffect(() => {
+    const removeAvailable = window.electronAPI?.onUpdateAvailable?.((version) => {
+      setUpdate({ phase: 'downloading', version })
+      setDismissed(false)
+    })
+    const removeDownloaded = window.electronAPI?.onUpdateDownloaded?.(() => {
+      setUpdate({ phase: 'ready' })
+      setDismissed(false)
+    })
+    return () => {
+      removeAvailable?.()
+      removeDownloaded?.()
+    }
+  }, [])
+
+  if (update.phase === 'idle' || dismissed) return null
+
+  return (
+    <div className={styles.updateBanner}>
+      {update.phase === 'downloading' && (
+        <span>Update v{update.version} available — downloading in the background…</span>
+      )}
+      {update.phase === 'ready' && (
+        <>
+          <span>Update ready to install.</span>
+          <div className={styles.updateBannerActions}>
+            <button
+              type="button"
+              className="secondary-btn"
+              onClick={() => window.electronAPI?.installUpdate?.()}
+            >
+              Restart Now
+            </button>
+            <button
+              type="button"
+              className="secondary-btn"
+              onClick={() => setDismissed(true)}
+            >
+              Later
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/JSM_GUI/jsm-gui-app/src/types/global.d.ts
+++ b/JSM_GUI/jsm-gui-app/src/types/global.d.ts
@@ -26,6 +26,8 @@ declare interface Window {
     openExternal?: (url: string) => Promise<void>
     onUpdateAvailable?: (callback: (version: string) => void) => () => void
     onUpdateDownloaded?: (callback: () => void) => () => void
+    onUpdateDownloadProgress?: (callback: (percent: number) => void) => () => void
+    downloadUpdate?: () => Promise<void>
     installUpdate?: () => Promise<void>
   }
   telemetry?: {

--- a/JSM_GUI/jsm-gui-app/src/types/global.d.ts
+++ b/JSM_GUI/jsm-gui-app/src/types/global.d.ts
@@ -24,6 +24,9 @@ declare interface Window {
     getBackendChoice?: () => Promise<'SDL' | 'legacy'>
     setBackendChoice?: (choice: 'SDL' | 'legacy') => Promise<{ success: boolean; backend: 'SDL' | 'legacy' }>
     openExternal?: (url: string) => Promise<void>
+    onUpdateAvailable?: (callback: (version: string) => void) => () => void
+    onUpdateDownloaded?: (callback: () => void) => () => void
+    installUpdate?: () => Promise<void>
   }
   telemetry?: {
     onSample?: (callback: (payload: unknown) => void) => () => void

--- a/JSM_GUI/jsm-gui-app/src/utils/configSerializer.ts
+++ b/JSM_GUI/jsm-gui-app/src/utils/configSerializer.ts
@@ -390,11 +390,11 @@ export function serializeConfig(parsed: ParsedConfig): string {
       ]
       const rank = (line: string) => {
         const keyPart = line.split('=')[0]?.trim().toUpperCase()
-        const d = defaultsOrder.indexOf(keyPart as typeof keyName[keyof typeof keyName])
+        const d = (defaultsOrder as string[]).indexOf(keyPart ?? '')
         if (d >= 0) return d
-        const l = leftOrder.indexOf(keyPart as typeof keyName[keyof typeof keyName])
+        const l = (leftOrder as string[]).indexOf(keyPart ?? '')
         if (l >= 0) return 100 + l
-        const r = rightOrder.indexOf(keyPart as typeof keyName[keyof typeof keyName])
+        const r = (rightOrder as string[]).indexOf(keyPart ?? '')
         if (r >= 0) return 200 + r
         return 1000
       }


### PR DESCRIPTION
- Switched the Windows build target from a plain .exe to an NSIS installer with silent install, per-user install directory selection, and desktop shortcut creation
- Integrated electron-updater to check for new GitHub releases on startup and notify the user via a banner
- Update banner has a staged UX: shows available version with "Download Now" / "Later", displays download progress percentage, then prompts "Restart Now" / "Later" when ready
- Profiles and startup config are preserved across updates — before installing, the app backs up profiles-library/ and OnStartUp.txt to userData, then restores them on the next launch before any file initialization runs
- Added a subtle version number to the sidebar footer for easy reference