### PR TITLE
Linux: Initial support and dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:24.04
+
+# Build tools
+RUN apt-get update && apt-get install -y \
+	build-essential \
+	cmake \
+	ninja-build \
+	pkg-config \
+	gdb \
+	git \
+	&& apt-get clean
+
+# Project dependencies
+RUN apt-get update && apt-get install -y \
+	libgtk-3-dev \
+	libappindicator3-dev \
+	libevdev-dev \
+    libhidapi-dev \
+	&& apt-get clean
+
+# SDL3 dependencies
+RUN apt-get update && apt-get install -y \
+	gnome-desktop-testing libasound2-dev libpulse-dev \
+	libaudio-dev libfribidi-dev libjack-dev libsndio-dev libx11-dev libxext-dev \
+	libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev libxtst-dev \
+	libxkbcommon-dev libdrm-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev \
+	libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev libthai-dev \
+	libpipewire-0.3-dev libwayland-dev libdecor-0-dev liburing-dev \
+	&& apt-get clean

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+  "name": "jsm_custom_curve-dev",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "customizations": {
+    "jetbrains": {
+      "backend": "CLion"
+    }
+  }
+}

--- a/JoyShockMapper/include/Gamepad.h
+++ b/JoyShockMapper/include/Gamepad.h
@@ -2,6 +2,7 @@
 
 #include "JoyShockMapper.h"
 #include "PlatformDefinitions.h"
+#include <chrono>
 
 struct Indicator
 {

--- a/JoyShockMapper/include/InputHelpers.h
+++ b/JoyShockMapper/include/InputHelpers.h
@@ -26,9 +26,9 @@ struct Command {
 #ifndef _WIN32
 extern int input_pipe_fd[2];
 
-extern std::queue<Command> commandQueue;
-extern std::mutex commandQueueMutex;
-extern std::condition_variable commandQueueCV;
+extern std::queue<Command>& commandQueue;
+extern std::mutex& commandQueueMutex;
+extern std::condition_variable& commandQueueCV;
 
 #endif
 
@@ -68,6 +68,10 @@ void initFifoCommandListener();
 tuple<string, string> GetActiveWindowName();
 
 vector<string> ListDirectory(string directory);
+
+#ifndef _WIN32
+void InitializeX11ErrorHandler();
+#endif
 
 string GetCWD();
 

--- a/JoyShockMapper/include/InputHelpers.h
+++ b/JoyShockMapper/include/InputHelpers.h
@@ -24,12 +24,9 @@ struct Command {
 #endif
 // Setup the input pipe for console input 
 #ifndef _WIN32
-extern int input_pipe_fd[2];
-
 extern std::queue<Command>& commandQueue;
 extern std::mutex& commandQueueMutex;
 extern std::condition_variable& commandQueueCV;
-
 #endif
 
 
@@ -61,7 +58,6 @@ BOOL WINAPI ConsoleCtrlHandler(DWORD dwCtrlType);
 
 // just setting up the console with standard stuff
 void initConsole();
-void initConsole(std::function<void()>);
 #ifndef _WIN32
 void initFifoCommandListener();
 #endif

--- a/JoyShockMapper/include/JoyShock.h
+++ b/JoyShockMapper/include/JoyShock.h
@@ -59,21 +59,6 @@ public:
 
 	float getSetting(SettingID index);
 
-	template<>
-	FloatXY getSetting<FloatXY>(SettingID index);
-
-	template<>
-	GyroSettings getSetting<GyroSettings>(SettingID index);
-
-	template<>
-	Color getSetting<Color>(SettingID index);
-
-	template<>
-	AdaptiveTriggerSetting getSetting<AdaptiveTriggerSetting>(SettingID index);
-
-	template<>
-	AxisSignPair getSetting<AxisSignPair>(SettingID index);
-
 	void getSmoothedGyro(float x, float y, float length, float bottomThreshold, float topThreshold, int maxSamples, float &outX, float &outY);
 	void applyGyroDecaySmoothing(float rawX, float rawY, float deltaTime, float smoothingTime, float threshold, float &outX, float &outY);
 	void disableGyroDecaySmoothing();
@@ -186,6 +171,21 @@ private:
 	vector<DstState> _triggerState; // State of analog triggers when skip mode is active
 	vector<deque<float>> _prevTriggerPosition;
 };
+
+template<>
+FloatXY JoyShock::getSetting<FloatXY>(SettingID index);
+
+template<>
+GyroSettings JoyShock::getSetting<GyroSettings>(SettingID index);
+
+template<>
+Color JoyShock::getSetting<Color>(SettingID index);
+
+template<>
+AdaptiveTriggerSetting JoyShock::getSetting<AdaptiveTriggerSetting>(SettingID index);
+
+template<>
+AxisSignPair JoyShock::getSetting<AxisSignPair>(SettingID index);
 
 template<typename E>
 optional<E> JoyShock::getSettingAtChord(SettingID id, ButtonID chord)

--- a/JoyShockMapper/src/DigitalButton.cpp
+++ b/JoyShockMapper/src/DigitalButton.cpp
@@ -1070,7 +1070,6 @@ DigitalButton::Context::Context(Gamepad::Callback virtualControllerCallback, sha
   : rightMainMotion(mainMotion)
 {
 	chordStack.push_front(ButtonID::NONE); // Always hold mapping none at the end to _handle modeshifts and chords
-#ifdef _WIN32
 	auto virtual_controller = SettingsManager::getV<ControllerScheme>(SettingID::VIRTUAL_CONTROLLER);
 	if (virtual_controller->value() != ControllerScheme::NONE)
 	{
@@ -1085,5 +1084,4 @@ DigitalButton::Context::Context(Gamepad::Callback virtualControllerCallback, sha
 			CERR << error << '\n';
 		}
 	}
-#endif
 }

--- a/JoyShockMapper/src/SDLWrapper.cpp
+++ b/JoyShockMapper/src/SDLWrapper.cpp
@@ -15,6 +15,16 @@
 #include <cstring>
 #include <span>
 
+#ifdef __linux__
+#include <fcntl.h>
+#include <unistd.h>
+#include <linux/input.h>
+#include <sys/ioctl.h>
+#include <dirent.h>
+#include <libevdev/libevdev.h>
+#include <libevdev/libevdev-uinput.h>
+#endif
+
 typedef struct
 {
 	Uint8 ucEnableBits1;              /* 0 */
@@ -559,7 +569,26 @@ public:
 		SDL_free(_joysticksArray);
 		int count = 0;
 		_joysticksArray = SDL_GetJoysticks(&count);
-		return count;
+
+		// Filter out JSM's own virtual controllers to prevent reconnection loops
+		// We filter by VID/PID because the kernel overrides our device name
+		int realCount = 0;
+		for (int i = 0; i < count; i++)
+		{
+			uint16_t vid = SDL_GetJoystickVendorForID(_joysticksArray[i]);
+			uint16_t pid = SDL_GetJoystickProductForID(_joysticksArray[i]);
+
+			// Skip JSM Virtual Controllers (VID 0x1209 = pid.codes for open source)
+			// PID 0x4a53 = "JS" (JSM Xbox), PID 0x4a54 = "JT" (JSM DS4)
+			bool isVirtualController = (vid == 0x1209 && (pid == 0x4a53 || pid == 0x4a54));
+
+			if (!isVirtualController)
+			{
+				realCount++;
+			}
+		}
+
+		return realCount;
 	}
 
 	int GetDeviceCount() override
@@ -580,13 +609,29 @@ public:
 			delete iter->second;
 			iter = _controllerMap.erase(iter);
 		}
-		for (int i = 0; i < size; i++)
+
+		int deviceIndex = 0;
+		for (int i = 0; i < size && deviceIndex < size; i++)
 		{
+			// Skip JSM's own virtual controllers by VID/PID
+			uint16_t vid = SDL_GetJoystickVendorForID(_joysticksArray[i]);
+			uint16_t pid = SDL_GetJoystickProductForID(_joysticksArray[i]);
+
+			// Skip JSM Virtual Controllers (VID 0x1209 = pid.codes for open source)
+			// PID 0x4a53 = "JS" (JSM Xbox), PID 0x4a54 = "JT" (JSM DS4)
+			bool isVirtualController = (vid == 0x1209 && (pid == 0x4a53 || pid == 0x4a54));
+
+			if (isVirtualController)
+			{
+				continue;
+			}
+
 			ControllerDevice *device = new ControllerDevice(_joysticksArray[i]);
 			if (device->isValid())
 			{
-				deviceHandleArray[i] = i + 1;
-				_controllerMap[deviceHandleArray[i]] = device;
+				deviceHandleArray[deviceIndex] = deviceIndex + 1;
+				_controllerMap[deviceHandleArray[deviceIndex]] = device;
+				deviceIndex++;
 			}
 			else
 			{
@@ -594,6 +639,13 @@ public:
 				delete device;
 			}
 		}
+
+		// Fill remaining slots with -1
+		for (int i = deviceIndex; i < size; i++)
+		{
+			deviceHandleArray[i] = -1;
+		}
+
 		return int(_controllerMap.size());
 	}
 

--- a/JoyShockMapper/src/TriggerEffectGenerator.cpp
+++ b/JoyShockMapper/src/TriggerEffectGenerator.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "TriggerEffectGenerator.h"
+#include <algorithm>
 #include <cstdint>
 #include <cmath>
 

--- a/JoyShockMapper/src/linux/Gamepad.cpp
+++ b/JoyShockMapper/src/linux/Gamepad.cpp
@@ -1,4 +1,10 @@
 #include "Gamepad.h"
+#include <libevdev/libevdev.h>
+#include <libevdev/libevdev-uinput.h>
+#include <linux/input.h>
+#include <fcntl.h>
+#include <cstring>
+#include <map>
 
 size_t Gamepad::_count = 0;
 
@@ -15,57 +21,309 @@ Gamepad::~Gamepad()
 
 class GamepadImpl : public Gamepad
 {
-public:
-	// TODO: Implement this class by interacting with some external virtual controller software
-
-	GamepadImpl()
+private:
+	libevdev* device_ = nullptr;
+	libevdev_uinput* uinput_device_ = nullptr;
+	ControllerScheme scheme_;
+	bool initialized_ = false;
+	std::string error_msg_;
+	
+	// Map JSM button codes to Linux input event codes
+	std::map<uint16_t, int> buttonMap_;
+	
+	// D-pad state tracking for combined presses
+	bool dpad_up_ = false;
+	bool dpad_down_ = false;
+	bool dpad_left_ = false;
+	bool dpad_right_ = false;
+	
+	void updateDpadX()
 	{
+		int value = 0;
+		if (dpad_left_ && !dpad_right_) value = -1;
+		else if (dpad_right_ && !dpad_left_) value = 1;
+		libevdev_uinput_write_event(uinput_device_, EV_ABS, ABS_HAT0X, value);
+	}
+	
+	void updateDpadY()
+	{
+		int value = 0;
+		if (dpad_up_ && !dpad_down_) value = -1;
+		else if (dpad_down_ && !dpad_up_) value = 1;
+		libevdev_uinput_write_event(uinput_device_, EV_ABS, ABS_HAT0Y, value);
+	}
+	
+	void initButtonMap()
+	{
+		// Xbox/PS button mappings to Linux gamepad buttons
+		buttonMap_[X_A] = BTN_SOUTH;      // A button
+		buttonMap_[X_B] = BTN_EAST;       // B button
+		buttonMap_[X_X] = BTN_NORTH;      // X button
+		buttonMap_[X_Y] = BTN_WEST;       // Y button
+		buttonMap_[X_LB] = BTN_TL;        // Left bumper
+		buttonMap_[X_RB] = BTN_TR;        // Right bumper
+		buttonMap_[X_BACK] = BTN_SELECT;  // Back/Select
+		buttonMap_[X_START] = BTN_START;  // Start
+		buttonMap_[X_GUIDE] = BTN_MODE;   // Guide/Home
+		buttonMap_[X_LS] = BTN_THUMBL;    // Left stick click
+		buttonMap_[X_RS] = BTN_THUMBR;    // Right stick click
+		
+		// PS buttons (same mappings)
+		buttonMap_[PS_CROSS] = BTN_SOUTH;
+		buttonMap_[PS_CIRCLE] = BTN_EAST;
+		buttonMap_[PS_SQUARE] = BTN_NORTH;
+		buttonMap_[PS_TRIANGLE] = BTN_WEST;
+		buttonMap_[PS_L1] = BTN_TL;
+		buttonMap_[PS_R1] = BTN_TR;
+		buttonMap_[PS_SHARE] = BTN_SELECT;
+		buttonMap_[PS_OPTIONS] = BTN_START;
+		buttonMap_[PS_HOME] = BTN_MODE;
+		buttonMap_[PS_L3] = BTN_THUMBL;
+		buttonMap_[PS_R3] = BTN_THUMBR;
+	}
 
+public:
+	GamepadImpl(ControllerScheme scheme)
+	  : scheme_(scheme)
+	{
+		initButtonMap();
+		
+		device_ = libevdev_new();
+		if (!device_)
+		{
+			error_msg_ = "Failed to create libevdev device";
+			return;
+		}
+		
+		// Set device name based on scheme
+		if (scheme == ControllerScheme::XBOX)
+		{
+			libevdev_set_name(device_, "JSM Virtual Xbox Controller");
+			libevdev_set_id_vendor(device_, 0x1209);  // pid.codes vendor ID (for open source projects)
+			libevdev_set_id_product(device_, 0x4a53); // "JS" in hex (JoyShockMapper)
+		}
+		else // DS4
+		{
+			libevdev_set_name(device_, "JSM Virtual DualShock 4");
+			libevdev_set_id_vendor(device_, 0x1209);  // pid.codes vendor ID (for open source projects)
+			libevdev_set_id_product(device_, 0x4a54); // "JT" in hex (JoyShockMapper Touchpad)
+		}
+		libevdev_set_id_bustype(device_, BUS_USB);
+		libevdev_set_id_version(device_, 0x0111);
+		
+		// Enable button events
+		libevdev_enable_event_type(device_, EV_KEY);
+		libevdev_enable_event_code(device_, EV_KEY, BTN_SOUTH, nullptr);    // A/Cross
+		libevdev_enable_event_code(device_, EV_KEY, BTN_EAST, nullptr);     // B/Circle
+		libevdev_enable_event_code(device_, EV_KEY, BTN_NORTH, nullptr);    // X/Square
+		libevdev_enable_event_code(device_, EV_KEY, BTN_WEST, nullptr);     // Y/Triangle
+		libevdev_enable_event_code(device_, EV_KEY, BTN_TL, nullptr);       // LB/L1
+		libevdev_enable_event_code(device_, EV_KEY, BTN_TR, nullptr);       // RB/R1
+		libevdev_enable_event_code(device_, EV_KEY, BTN_SELECT, nullptr);   // Back/Share
+		libevdev_enable_event_code(device_, EV_KEY, BTN_START, nullptr);    // Start/Options
+		libevdev_enable_event_code(device_, EV_KEY, BTN_MODE, nullptr);     // Guide/Home
+		libevdev_enable_event_code(device_, EV_KEY, BTN_THUMBL, nullptr);   // L3
+		libevdev_enable_event_code(device_, EV_KEY, BTN_THUMBR, nullptr);   // R3
+		libevdev_enable_event_code(device_, EV_KEY, BTN_TL2, nullptr);      // LT (digital)
+		libevdev_enable_event_code(device_, EV_KEY, BTN_TR2, nullptr);      // RT (digital)
+		
+		// Enable absolute axes for sticks and triggers
+		libevdev_enable_event_type(device_, EV_ABS);
+		
+		// Left stick (X, Y)
+		struct input_absinfo absinfo;
+		memset(&absinfo, 0, sizeof(absinfo));
+		absinfo.minimum = -32768;
+		absinfo.maximum = 32767;
+		absinfo.fuzz = 255;
+		absinfo.flat = 4095;
+		libevdev_enable_event_code(device_, EV_ABS, ABS_X, &absinfo);
+		libevdev_enable_event_code(device_, EV_ABS, ABS_Y, &absinfo);
+		
+		// Right stick (RX, RY)
+		libevdev_enable_event_code(device_, EV_ABS, ABS_RX, &absinfo);
+		libevdev_enable_event_code(device_, EV_ABS, ABS_RY, &absinfo);
+		
+		// Triggers (Z, RZ) - analog
+		struct input_absinfo triggerinfo;
+		memset(&triggerinfo, 0, sizeof(triggerinfo));
+		triggerinfo.minimum = 0;
+		triggerinfo.maximum = 255;
+		libevdev_enable_event_code(device_, EV_ABS, ABS_Z, &triggerinfo);   // Left trigger
+		libevdev_enable_event_code(device_, EV_ABS, ABS_RZ, &triggerinfo);  // Right trigger
+		
+		// D-pad (HAT0X, HAT0Y)
+		struct input_absinfo hatinfo;
+		memset(&hatinfo, 0, sizeof(hatinfo));
+		hatinfo.minimum = -1;
+		hatinfo.maximum = 1;
+		libevdev_enable_event_code(device_, EV_ABS, ABS_HAT0X, &hatinfo);
+		libevdev_enable_event_code(device_, EV_ABS, ABS_HAT0Y, &hatinfo);
+		
+		// Create the uinput device
+		int error = libevdev_uinput_create_from_device(device_,
+		                                               LIBEVDEV_UINPUT_OPEN_MANAGED,
+		                                               &uinput_device_);
+		
+		if (error != 0)
+		{
+			error_msg_ = "Failed to create uinput device: ";
+			error_msg_ += strerror(-error);
+			libevdev_free(device_);
+			device_ = nullptr;
+			return;
+		}
+		
+		initialized_ = true;
 	}
 
 	virtual ~GamepadImpl()
 	{
-
+		if (uinput_device_)
+		{
+			libevdev_uinput_destroy(uinput_device_);
+		}
+		if (device_)
+		{
+			libevdev_free(device_);
+		}
 	}
 
-    // is not overriding anything? removed override from function
-	virtual bool isInitialized(std::string* errorMsg = nullptr) {
-
+	virtual bool isInitialized(std::string* errorMsg = nullptr) const override
+	{
+		if (errorMsg && !initialized_)
+		{
+			*errorMsg = error_msg_;
+		}
+		return initialized_;
 	}
 
 	virtual void setButton(KeyCode btn, bool pressed) override
 	{
-
+		if (!initialized_) return;
+		
+		auto it = buttonMap_.find(btn.code);
+		if (it != buttonMap_.end())
+		{
+			libevdev_uinput_write_event(uinput_device_, EV_KEY, it->second, pressed ? 1 : 0);
+		}
+		// Handle D-pad separately - track state for combined presses
+		else if (btn.code == X_UP || btn.code == PS_UP)
+		{
+			dpad_up_ = pressed;
+			updateDpadY();
+		}
+		else if (btn.code == X_DOWN || btn.code == PS_DOWN)
+		{
+			dpad_down_ = pressed;
+			updateDpadY();
+		}
+		else if (btn.code == X_LEFT || btn.code == PS_LEFT)
+		{
+			dpad_left_ = pressed;
+			updateDpadX();
+		}
+		else if (btn.code == X_RIGHT || btn.code == PS_RIGHT)
+		{
+			dpad_right_ = pressed;
+			updateDpadX();
+		}
+		// Handle digital trigger presses
+		else if (btn.code == X_LT || btn.code == PS_L2)
+		{
+			setLeftTrigger(pressed ? 1.0f : 0.0f);
+		}
+		else if (btn.code == X_RT || btn.code == PS_R2)
+		{
+			setRightTrigger(pressed ? 1.0f : 0.0f);
+		}
 	}
 
 	virtual void setLeftStick(float x, float y) override
 	{
-
+		if (!initialized_) return;
+		
+		// Convert -1.0 to 1.0 range to -32768 to 32767
+		int xVal = static_cast<int>(x * 32767.0f);
+		int yVal = static_cast<int>(-y * 32767.0f);
+		
+		libevdev_uinput_write_event(uinput_device_, EV_ABS, ABS_X, xVal);
+		libevdev_uinput_write_event(uinput_device_, EV_ABS, ABS_Y, yVal);
 	}
 
 	virtual void setRightStick(float x, float y) override
 	{
-
+		if (!initialized_) return;
+		
+		// Convert -1.0 to 1.0 range to -32768 to 32767
+		int xVal = static_cast<int>(x * 32767.0f);
+		int yVal = static_cast<int>(-y * 32767.0f);
+		
+		libevdev_uinput_write_event(uinput_device_, EV_ABS, ABS_RX, xVal);
+		libevdev_uinput_write_event(uinput_device_, EV_ABS, ABS_RY, yVal);
 	}
-
-	virtual void setLeftTrigger(float) override
-	{
-
-	}
-
-	virtual void setRightTrigger(float) override
-	{
 	
+	virtual void setStick(float x, float y, bool isLeft) override
+	{
+		if (isLeft)
+		{
+			setLeftStick(x, y);
+		}
+		else
+		{
+			setRightStick(x, y);
+		}
+	}
+
+	virtual void setLeftTrigger(float value) override
+	{
+		if (!initialized_) return;
+		
+		// Convert 0.0 to 1.0 range to 0 to 255
+		int val = static_cast<int>(value * 255.0f);
+		libevdev_uinput_write_event(uinput_device_, EV_ABS, ABS_Z, val);
+		
+		// Also set digital trigger button if pressed enough
+		libevdev_uinput_write_event(uinput_device_, EV_KEY, BTN_TL2, value > 0.5f ? 1 : 0);
+	}
+
+	virtual void setRightTrigger(float value) override
+	{
+		if (!initialized_) return;
+		
+		// Convert 0.0 to 1.0 range to 0 to 255
+		int val = static_cast<int>(value * 255.0f);
+		libevdev_uinput_write_event(uinput_device_, EV_ABS, ABS_RZ, val);
+		
+		// Also set digital trigger button if pressed enough
+		libevdev_uinput_write_event(uinput_device_, EV_KEY, BTN_TR2, value > 0.5f ? 1 : 0);
 	}
 
 	virtual void update() override
 	{
-
+		if (!initialized_) return;
+		
+		// Send SYN_REPORT to commit all changes
+		libevdev_uinput_write_event(uinput_device_, EV_SYN, SYN_REPORT, 0);
+	}
+	
+	virtual ControllerScheme getType() const override
+	{
+		return scheme_;
+	}
+	
+	virtual void setGyro(TimePoint now, float accelX, float accelY, float accelZ, float gyroX, float gyroY, float gyroZ) override
+	{
+		// Not implemented for basic gamepad - could be added for DS4 motion support
+	}
+	
+	virtual void setTouchState(optional<FloatXY> press1, optional<FloatXY> press2) override
+	{
+		// Not implemented for basic gamepad - could be added for DS4 touchpad support
 	}
 };
 
 Gamepad *Gamepad::getNew(ControllerScheme scheme, Callback notification)
 {
-	// return new GamepadImpl();
-	return nullptr;
+	return new GamepadImpl(scheme);
 }

--- a/JoyShockMapper/src/linux/InputHelpers.cpp
+++ b/JoyShockMapper/src/linux/InputHelpers.cpp
@@ -24,9 +24,18 @@
 #include <mutex>
 #include <condition_variable>
 
-std::queue<Command> commandQueue;
-std::mutex commandQueueMutex;
-std::condition_variable commandQueueCV;
+// Heap allocate and never delete to prevent destruction during program exit
+// The FIFO thread is detached and may still be running when globals are destroyed
+static std::queue<Command>* commandQueuePtr = new std::queue<Command>();
+static std::mutex* commandQueueMutexPtr = new std::mutex();
+static std::condition_variable* commandQueueCVPtr = new std::condition_variable();
+
+// Provide global references for compatibility
+std::queue<Command>& commandQueue = *commandQueuePtr;
+std::mutex& commandQueueMutex = *commandQueueMutexPtr;
+std::condition_variable& commandQueueCV = *commandQueueCVPtr;
+
+static std::atomic<bool> fifoThreadShouldExit{ false };
 #include <termios.h>
 #include <dlfcn.h>
 
@@ -47,6 +56,16 @@ static int (*XFetchName)(void *, X11Window, char **);
 static X11Atom (*XInternAtom)(void *, const char *, int);
 static int (*XGetWindowProperty)(void *, X11Window, X11Atom, long, long, int, X11Atom, X11Atom *, int *, unsigned long *, unsigned long *, unsigned char **);
 static int (*XFree)(void *);
+static int (*XSetErrorHandler)(int (*handler)(void *, void *));
+static int (*XSync)(void *, int);
+
+// X11 error handler to prevent crashes on invalid windows
+static std::atomic<bool> x11ErrorOccurred{ false };
+static int X11ErrorHandler(void *, void *)
+{
+	x11ErrorOccurred = true;
+	return 0; // Return value is ignored
+}
 
 // Windows' mouse speed settings translate non-linearly to speed.
 // Thankfully, the mappings are available here:
@@ -619,7 +638,7 @@ void initConsole(std::function<void()>)
 	});
 }
 
-std::tuple<std::string, std::string> GetActiveWindowName()
+static void InitializeX11()
 {
 	if (X11Display == nullptr)
 	{
@@ -633,11 +652,29 @@ std::tuple<std::string, std::string> GetActiveWindowName()
 			XInternAtom = reinterpret_cast<decltype(XInternAtom)>(::dlsym(libX11, "XInternAtom"));
 			XGetWindowProperty = reinterpret_cast<decltype(XGetWindowProperty)>(::dlsym(libX11, "XGetWindowProperty"));
 			XFree = reinterpret_cast<decltype(XFree)>(::dlsym(libX11, "XFree"));
+			XSetErrorHandler = reinterpret_cast<decltype(XSetErrorHandler)>(::dlsym(libX11, "XSetErrorHandler"));
+			XSync = reinterpret_cast<decltype(XSync)>(::dlsym(libX11, "XSync"));
 
 			X11Display = XOpenDisplay(nullptr);
 			_NET_WM_PID = XInternAtom(X11Display, "_NET_WM_PID", true);
+			
+			// Set up error handler to prevent crashes on X11 errors
+			if (XSetErrorHandler)
+			{
+				XSetErrorHandler(X11ErrorHandler);
+			}
 		}
 	}
+}
+
+void InitializeX11ErrorHandler()
+{
+	InitializeX11();
+}
+
+std::tuple<std::string, std::string> GetActiveWindowName()
+{
+	InitializeX11();
 
 	std::tuple<std::string, std::string> result;
 
@@ -652,17 +689,38 @@ std::tuple<std::string, std::string> GetActiveWindowName()
 
 		focusedWindowExecutableName[0] = '\0';
 		XGetInputFocus(X11Display, &focusedWindow, &revert);
-		if (focusedWindow > 0)
+		// Check for valid window (None = 0, PointerRoot = 1 are not valid windows)
+		if (focusedWindow > 1)
 		{
+			// Reset error flag before attempting X11 operations
+			x11ErrorOccurred = false;
+			
 			XFetchName(X11Display, focusedWindow, &focusedWindowName);
+			
+			// Sync to process any pending errors
+			if (XSync)
+			{
+				XSync(X11Display, 0);
+			}
+			
+			// Only proceed if no error occurred
+			if (!x11ErrorOccurred)
+			{
+				X11Atom type;
+				int format;
+				unsigned long itemCount;
+				unsigned long bytesAfter;
 
-			X11Atom type;
-			int format;
-			unsigned long itemCount;
-			unsigned long bytesAfter;
-
-			XGetWindowProperty(X11Display, focusedWindow, _NET_WM_PID, 0, 1, false, 0, &type, &format, &itemCount, &bytesAfter, &processPID);
-			if (processPID != nullptr)
+				XGetWindowProperty(X11Display, focusedWindow, _NET_WM_PID, 0, 1, false, 0, &type, &format, &itemCount, &bytesAfter, &processPID);
+				
+				// Sync again to catch any errors from XGetWindowProperty
+				if (XSync)
+				{
+					XSync(X11Display, 0);
+				}
+			}
+			
+			if (processPID != nullptr && !x11ErrorOccurred)
 			{
 				const auto pid = *reinterpret_cast<unsigned long *>(processPID);
 				XFree(processPID);
@@ -777,6 +835,8 @@ bool ClearConsole() {
 
 void ReleaseConsole()
 {
+	// Signal the FIFO thread to exit
+	fifoThreadShouldExit = true;
 }
 
 void UnhideConsole() {
@@ -821,7 +881,7 @@ void initFifoCommandListener()
             return;
         }
 
-        while (true) {
+        while (!fifoThreadShouldExit) {
             char* lineptr = nullptr;
             size_t n = 0;
             ssize_t read_len = getline(&lineptr, &n, fifo_file);

--- a/JoyShockMapper/src/linux/InputHelpers.cpp
+++ b/JoyShockMapper/src/linux/InputHelpers.cpp
@@ -612,29 +612,16 @@ BOOL ConsoleCtrlHandler(DWORD)
 };
 
 // just setting up the console with standard stuff
-void initConsole(std::function<void()>)
+void initConsole()
 {
 	static std::thread consoleForwardThread([](){
-		std::cout << "[DEBUG] consoleForwardThread started" << std::endl;
 		std::string line;
-		while (true)
+		while (std::getline(std::cin, line))
 		{
-			if (!std::getline(std::cin, line))
-			{
-				std::cout << "[DEBUG] consoleForwardThread: EOF or error on cin" << std::endl;
-				break;
-			}
-
-			std::cout << "[DEBUG] consoleForwardThread: read line from cin: " << line << std::endl;
-
-			// Forward input to input_pipe_fd[1], mimicking WriteToConsole
-			{
-				std::lock_guard<std::mutex> lock(commandQueueMutex);
-				commandQueue.push(Command{line, CommandSource::CONSOLE});
-				commandQueueCV.notify_one();
-			}
+			std::lock_guard<std::mutex> lock(commandQueueMutex);
+			commandQueue.push(Command{line, CommandSource::CONSOLE});
+			commandQueueCV.notify_one();
 		}
-		std::cout << "[DEBUG] consoleForwardThread exiting" << std::endl;
 	});
 }
 
@@ -802,31 +789,6 @@ void HideConsole()
 
 void ShowConsole()
 {
-}
-void initConsole() {
-	static std::thread ttyForwardThread([](){
-		FILE* tty = fopen("/dev/tty", "r");
-		if (!tty) {
-			perror("fopen /dev/tty");
-			return;
-		}
-		char* lineptr = nullptr;
-		size_t n = 0;
-		while (true) {
-			ssize_t read = getline(&lineptr, &n, tty);
-			if (read == -1) {
-				break;
-			}
-
-			{
-				std::lock_guard<std::mutex> lock(commandQueueMutex);
-				commandQueue.push(Command{std::string(lineptr, read), CommandSource::CONSOLE});
-				commandQueueCV.notify_one();
-			}
-		}
-		free(lineptr);
-		fclose(tty);
-	});
 }
 
 bool ClearConsole() {

--- a/JoyShockMapper/src/linux/PlatformDefinitions.cpp
+++ b/JoyShockMapper/src/linux/PlatformDefinitions.cpp
@@ -406,5 +406,147 @@ WORD nameToKey(string_view name)
 	{
 		return GYRO_OFF_BIND;
 	}
+	// Xbox virtual controller buttons
+	if (name.compare("X_UP") == 0)
+	{
+		return X_UP;
+	}
+	if (name.compare("X_DOWN") == 0)
+	{
+		return X_DOWN;
+	}
+	if (name.compare("X_LEFT") == 0)
+	{
+		return X_LEFT;
+	}
+	if (name.compare("X_RIGHT") == 0)
+	{
+		return X_RIGHT;
+	}
+	if (name.compare("X_LB") == 0)
+	{
+		return X_LB;
+	}
+	if (name.compare("X_RB") == 0)
+	{
+		return X_RB;
+	}
+	if (name.compare("X_X") == 0)
+	{
+		return X_X;
+	}
+	if (name.compare("X_A") == 0)
+	{
+		return X_A;
+	}
+	if (name.compare("X_Y") == 0)
+	{
+		return X_Y;
+	}
+	if (name.compare("X_B") == 0)
+	{
+		return X_B;
+	}
+	if (name.compare("X_LS") == 0)
+	{
+		return X_LS;
+	}
+	if (name.compare("X_RS") == 0)
+	{
+		return X_RS;
+	}
+	if (name.compare("X_BACK") == 0)
+	{
+		return X_BACK;
+	}
+	if (name.compare("X_START") == 0)
+	{
+		return X_START;
+	}
+	if (name.compare("X_GUIDE") == 0)
+	{
+		return X_GUIDE;
+	}
+	if (name.compare("X_LT") == 0)
+	{
+		return X_LT;
+	}
+	if (name.compare("X_RT") == 0)
+	{
+		return X_RT;
+	}
+	// PlayStation virtual controller buttons (aliases)
+	if (name.compare("PS_UP") == 0)
+	{
+		return PS_UP;
+	}
+	if (name.compare("PS_DOWN") == 0)
+	{
+		return PS_DOWN;
+	}
+	if (name.compare("PS_LEFT") == 0)
+	{
+		return PS_LEFT;
+	}
+	if (name.compare("PS_RIGHT") == 0)
+	{
+		return PS_RIGHT;
+	}
+	if (name.compare("PS_L1") == 0)
+	{
+		return PS_L1;
+	}
+	if (name.compare("PS_R1") == 0)
+	{
+		return PS_R1;
+	}
+	if (name.compare("PS_SQUARE") == 0)
+	{
+		return PS_SQUARE;
+	}
+	if (name.compare("PS_CROSS") == 0)
+	{
+		return PS_CROSS;
+	}
+	if (name.compare("PS_TRIANGLE") == 0)
+	{
+		return PS_TRIANGLE;
+	}
+	if (name.compare("PS_CIRCLE") == 0)
+	{
+		return PS_CIRCLE;
+	}
+	if (name.compare("PS_L3") == 0)
+	{
+		return PS_L3;
+	}
+	if (name.compare("PS_R3") == 0)
+	{
+		return PS_R3;
+	}
+	if (name.compare("PS_SHARE") == 0)
+	{
+		return PS_SHARE;
+	}
+	if (name.compare("PS_OPTIONS") == 0)
+	{
+		return PS_OPTIONS;
+	}
+	if (name.compare("PS_HOME") == 0)
+	{
+		return PS_HOME;
+	}
+	if (name.compare("PS_PAD_CLICK") == 0)
+	{
+		return PS_PAD_CLICK;
+	}
+	if (name.compare("PS_L2") == 0)
+	{
+		return PS_L2;
+	}
+	if (name.compare("PS_R2") == 0)
+	{
+		return PS_R2;
+	}
 	return 0x00;
 }

--- a/JoyShockMapper/src/linux/StatusNotifierItem.cpp
+++ b/JoyShockMapper/src/linux/StatusNotifierItem.cpp
@@ -1,6 +1,8 @@
 #include "linux/StatusNotifierItem.h"
 
 #include <cstring>
+#include <iostream>
+#include <future>
 #include <libappindicator/app-indicator.h>
 
 
@@ -11,45 +13,58 @@ TrayIcon *TrayIcon::getNew(TrayIconData applicationName, std::function<void()> &
 
 
 StatusNotifierItem::StatusNotifierItem(TrayIconData, std::function<void()> &&beforeShow)
-  : thread_{ [this, &beforeShow] {
-	  int argc = 0;
-	  gtk_init(&argc, nullptr);
-
-	  std::string iconPath{};
-	  const auto APPDIR = ::getenv("APPDIR");
-	  if (APPDIR != nullptr)
-	  {
-		  iconPath = APPDIR;
-		  iconPath += "/usr/share/icons/hicolor/24x24/status/jsm-status-dark.svg";
-		  gtk_icon_theme_prepend_search_path(gtk_icon_theme_get_default(), iconPath.c_str());
-	  }
-	  else
-	  {
-		  iconPath = "jsm-status-dark";
-	  }
-
-	  menu_ = std::unique_ptr<GtkMenu, decltype(&::g_object_unref)>{ GTK_MENU(gtk_menu_new()), &g_object_unref };
-
-	  indicator_ = app_indicator_new(APPLICATION_RDN APPLICATION_NAME, iconPath.c_str(), APP_INDICATOR_CATEGORY_APPLICATION_STATUS);
-	  app_indicator_set_status(indicator_, APP_INDICATOR_STATUS_ACTIVE);
-	  app_indicator_set_menu(indicator_, menu_.get());
-
-	  beforeShow();
-
-	  gtk_main();
-  } }
 {
+	// Start the GTK thread - capture beforeShow by value to avoid dangling reference
+	thread_ = std::thread([this, beforeShow = std::move(beforeShow)] {
+		int argc = 0;
+		if (!gtk_init_check(&argc, nullptr))
+		{
+			// GTK initialization failed - cannot create tray icon
+			// Just exit the thread silently
+			return;
+		}
+
+		std::string iconPath{};
+		const auto APPDIR = ::getenv("APPDIR");
+		if (APPDIR != nullptr)
+		{
+			iconPath = APPDIR;
+			iconPath += "/usr/share/icons/hicolor/24x24/status/jsm-status-dark.svg";
+			gtk_icon_theme_prepend_search_path(gtk_icon_theme_get_default(), iconPath.c_str());
+		}
+		else
+		{
+			iconPath = "jsm-status-dark";
+		}
+
+		menu_ = std::unique_ptr<GtkMenu, decltype(&::g_object_unref)>{ GTK_MENU(gtk_menu_new()), &g_object_unref };
+
+		indicator_ = app_indicator_new(APPLICATION_RDN APPLICATION_NAME, iconPath.c_str(), APP_INDICATOR_CATEGORY_APPLICATION_STATUS);
+		app_indicator_set_status(indicator_, APP_INDICATOR_STATUS_ACTIVE);
+		app_indicator_set_menu(indicator_, menu_.get());
+
+		beforeShow();
+
+		gtk_main();
+	});
 }
 
 StatusNotifierItem::~StatusNotifierItem()
 {
-	g_idle_add([](void *) -> int {
-		gtk_main_quit();
-		return false;
-	},
-	  this);
+	if (thread_.joinable())
+	{
+		// Request GTK to quit
+		g_idle_add([](void *) -> int {
+			gtk_main_quit();
+			return false;
+		},
+		  this);
 
-	thread_.join();
+		// Detach the thread instead of joining to avoid blocking on GTK shutdown
+		// This prevents std::terminate() from being called if the thread can't be joined cleanly
+		// The GTK thread will exit on its own when gtk_main() returns
+		thread_.detach();
+	}
 }
 
 bool StatusNotifierItem::Show()

--- a/JoyShockMapper/src/main.cpp
+++ b/JoyShockMapper/src/main.cpp
@@ -55,6 +55,7 @@ vector<pair<int, int>> g_ignoreGyroVidPid;
 unique_ptr<PollingThread> minimizeThread;
 bool devicesCalibrating = false;
 unordered_map<int, shared_ptr<JoyShock>> handle_to_joyshock;
+std::mutex handle_to_joyshock_mutex;
 
 int input_pipe_fd[2];
 int triggerCalibrationStep = 0;
@@ -170,7 +171,11 @@ struct TOUCH_POINT
 
 void touchCallback(int jcHandle, TOUCH_STATE newState, TOUCH_STATE prevState, float delta_time)
 {
-
+	shared_ptr<JoyShock> js;
+	{
+		std::lock_guard<std::mutex> guard(handle_to_joyshock_mutex);
+		js = handle_to_joyshock[jcHandle];
+	}
 	// if (current.t0Down || previous.t0Down)
 	//{
 	//	DisplayTouchInfo(newState.t0Down ? newState.t0Id : prevState.t0Id,
@@ -185,7 +190,6 @@ void touchCallback(int jcHandle, TOUCH_STATE newState, TOUCH_STATE prevState, fl
 	//	  prevState.t1Down ? optional<FloatXY>({ prevState.t1X, prevState.t1Y }) : nullopt);
 	//}
 
-	shared_ptr<JoyShock> js = handle_to_joyshock[jcHandle];
 	int tpSizeX, tpSizeY;
 	if (!js || jsl->GetTouchpadDimension(jcHandle, tpSizeX, tpSizeY) == false)
 		return;
@@ -426,8 +430,11 @@ void calibrateTriggers(shared_ptr<JoyShock> jc)
 
 void joyShockPollCallback(int jcHandle, JOY_SHOCK_STATE state, JOY_SHOCK_STATE lastState, IMU_STATE imuState, IMU_STATE lastImuState, float deltaTime)
 {
-
-	shared_ptr<JoyShock> jc = handle_to_joyshock[jcHandle];
+	shared_ptr<JoyShock> jc;
+	{
+		std::lock_guard<std::mutex> guard(handle_to_joyshock_mutex);
+		jc = handle_to_joyshock[jcHandle];
+	}
 	if (jc == nullptr)
 		return;
 	jc->_context->callback_lock.lock();
@@ -1612,6 +1619,7 @@ void joyShockPollCallback(int jcHandle, JOY_SHOCK_STATE state, JOY_SHOCK_STATE l
 
 void connectDevices(bool mergeJoycons = true)
 {
+	std::lock_guard<std::mutex> guard(handle_to_joyshock_mutex);
 	handle_to_joyshock.clear();
 	this_thread::sleep_for(100ms);
 	int numConnected = jsl->ConnectDevices();
@@ -1845,9 +1853,12 @@ bool do_CALCULATE_REAL_WORLD_CALIBRATION(string_view argument)
 bool do_FINISH_GYRO_CALIBRATION()
 {
 	COUT << "Finishing continuous calibration for all devices\n";
-	for (auto iter = handle_to_joyshock.begin(); iter != handle_to_joyshock.end(); ++iter)
 	{
-		iter->second->_motion->PauseContinuousCalibration();
+		std::lock_guard<std::mutex> guard(handle_to_joyshock_mutex);
+		for (auto iter = handle_to_joyshock.begin(); iter != handle_to_joyshock.end(); ++iter)
+		{
+			iter->second->_motion->PauseContinuousCalibration();
+		}
 	}
 	devicesCalibrating = false;
 	return true;
@@ -1856,10 +1867,13 @@ bool do_FINISH_GYRO_CALIBRATION()
 bool do_RESTART_GYRO_CALIBRATION()
 {
 	COUT << "Restarting continuous calibration for all devices\n";
-	for (auto iter = handle_to_joyshock.begin(); iter != handle_to_joyshock.end(); ++iter)
 	{
-		iter->second->_motion->ResetContinuousCalibration();
-		iter->second->_motion->StartContinuousCalibration();
+		std::lock_guard<std::mutex> guard(handle_to_joyshock_mutex);
+		for (auto iter = handle_to_joyshock.begin(); iter != handle_to_joyshock.end(); ++iter)
+		{
+			iter->second->_motion->ResetContinuousCalibration();
+			iter->second->_motion->StartContinuousCalibration();
+		}
 	}
 	devicesCalibrating = true;
 	return true;
@@ -1868,9 +1882,12 @@ bool do_RESTART_GYRO_CALIBRATION()
 bool do_SET_MOTION_STICK_NEUTRAL()
 {
 	COUT << "Setting neutral motion stick orientation...\n";
-	for (auto iter = handle_to_joyshock.begin(); iter != handle_to_joyshock.end(); ++iter)
 	{
-		iter->second->set_neutral_quat = true;
+		std::lock_guard<std::mutex> guard(handle_to_joyshock_mutex);
+		for (auto iter = handle_to_joyshock.begin(); iter != handle_to_joyshock.end(); ++iter)
+		{
+			iter->second->set_neutral_quat = true;
+		}
 	}
 	return true;
 }
@@ -3442,6 +3459,8 @@ int main(int argc, char *argv[])
 	// The pipe is used to receive commands from the console
 	// to the main thread
 	initFifoCommandListener();
+	// Initialize X11 error handler early to prevent GTK from crashing on X11 errors
+	InitializeX11ErrorHandler();
 	#endif
 	COUT_BOLD << "Welcome to JoyShockMapper version " << version << "!\n";
 	// if (whitelister) COUT << "JoyShockMapper was successfully whitelisted!\n";
@@ -3531,11 +3550,18 @@ int main(int argc, char *argv[])
 	connectDevices();
 	jsl->SetCallback(&joyShockPollCallback);
 	jsl->SetTouchCallback(&touchCallback);
+	
+#ifndef _WIN32
+	// On Linux, skip tray icon creation to avoid GTK issues in headless environments
+	// Tray icons require a working display server and window manager
+	COUT << "Tray icon disabled on Linux.\n";
+#else
 	tray.reset(TrayIcon::getNew(trayIconData, &beforeShowTrayMenu));
 	if (tray)
 	{
 		tray->Show();
 	}
+#endif
 
 	do_RESET_MAPPINGS(&commandRegistry); // OnReset.txt
 	if (commandRegistry.loadConfigFile("OnStartup.txt"))
@@ -3585,5 +3611,12 @@ int main(int argc, char *argv[])
 	LocalFree(argv);
 #endif
 	cleanUp();
+#ifndef _WIN32
+	// On Linux, use _exit() to skip global destructors
+	// This prevents std::terminate from being called by destructors of global objects
+	// that may have threads still running
+	_exit(0);
+#else
 	return 0;
+#endif
 }

--- a/JoyShockMapper/src/main.cpp
+++ b/JoyShockMapper/src/main.cpp
@@ -57,7 +57,6 @@ bool devicesCalibrating = false;
 unordered_map<int, shared_ptr<JoyShock>> handle_to_joyshock;
 std::mutex handle_to_joyshock_mutex;
 
-int input_pipe_fd[2];
 int triggerCalibrationStep = 0;
 
 static void UpdateIgnoredGyroDevices()
@@ -3421,18 +3420,6 @@ int __stdcall wWinMain(HINSTANCE hInstance, HINSTANCE prevInstance, LPWSTR cmdLi
 #else
 int main(int argc, char *argv[])
 {
-#if !defined(_WIN32)
-	if (pipe(input_pipe_fd) == -1)
-	{
-		perror("pipe");
-		exit(EXIT_FAILURE);
-	}
-	if (dup2(input_pipe_fd[0], STDIN_FILENO) == -1)
-	{
-		perror("dup2");
-		exit(EXIT_FAILURE);
-	}
-#endif
 	static_cast<void>(argc);
 	static_cast<void>(argv);
 	void *trayIconData = nullptr;


### PR DESCRIPTION
# Description
This PR adds initial Linux support to JSM, including virtual controller support, and a [dev container](https://containers.dev/) for developing/building the project in a Linux environment (should be supported by Visual Studio, VSCode and CLion).

Many changes were borrowed from @CoderMaximus's [JoyShockMapper-linux](https://github.com/CoderMaximus/JoyShockMapper-linux) fork, minus some out-of-scope changes (odd stick Y flipping, new KEY_ commands, MAP_TO_XBOX command).

Tested on Nobara Linux 43. Should work on most distros.

# Build Instructions
Docker is used to make building reproducible across systems. Most Linux devs should be comfortable with this, and it can also be done from Windows.

Unlike JoyShockMapper-linux, clang++ is not needed.

```bash
docker build -t jsm-build .devcontainer/
docker run --rm -u $UID -v .:/data jsm-build bash -c ' \
	mkdir -p /data/build-jsm-sdl && cd /data/build-jsm-sdl && \
	cmake .. -G Ninja -D SDL=ON && \
	cmake --build . --config Release'
```

# Known Limitations
* No system tray icon or console interface. Users must launch JSM from the terminal.
* If any dependencies get added to the project, `.devcontainer/Dockerfile` needs to be updated.
* JSM Legacy builds and runs, but crashes instantly. This is likely a problem with JoyShockLibrary, and may not be worth fixing for Linux.
* Electron GUI runs in dev mode, but fails to build. It can create/edit profiles (albeit in the wrong folder), but can't communicate with JSM. This PR doesn't fix this.
* Users *may* have to do some post-install setup, but this wasn't the case on my system. See [this script from the CoderMaximus fork](https://github.com/CoderMaximus/JoyShockMapper-linux/blob/master/install_udev_rules.sh).

# Open Questions
* Commit 9cbef64 adds some Linux specific code to `SDLWrapper.cpp`. I could wrap these changes in an ifdef, but it shouldn't hurt to keep it as is either.
* Commit c5bdbfc adds a mutex to `main.cpp` when accessing `handle_to_joyshock`. I'm not certain why this is done, but it shouldn't harm anything.
* I purposely haven't updated `README.md`, as only part of the project can be built (JSM SDL). Adding a small notice and highlighting the Docker usage may be enough.

If you intend to package/publish this in an unfinished state, bundling the built `JoyShockMapper` binary alongside `dist/linux/50-joyshockmapper.rules` in a tarball would already be helpful to Linux users. The default configs within `dist/linux` should NOT be included, as JSM creates them in a different folder upon launch (Linux users should understand this). In the future, possibly once the GUI is fixed, an install script could be provided.