### PR TITLE
Add Steam Controller support and the latest SDL3 functionality

### DIFF
--- a/JSM_GUI/jsm-gui-app/src/assets/docs/JSM-docs.md
+++ b/JSM_GUI/jsm-gui-app/src/assets/docs/JSM-docs.md
@@ -30,6 +30,7 @@
   * **[Modeshifts](#7-modeshifts)**
   * **[Touchpad](#8-touchpad)**
     * **[Touch Sticks](#81-touch-sticks)**
+    * **[Dual Trackpads](#82-dual-trackpads)**
   * **[Miscellaneous Commands](#9-miscellaneous-commands)**
 * **[Configuration Files](#configuration-files)**
   * **[OnStartup.txt](#1-onstartuptxt)**
@@ -108,9 +109,15 @@ TOUCH : The Playstation touchpad senses a finger
 MIC: The Sony Dualsense microphone button
 LTOUCH: Left stick capacitive touch
 RTOUCH: Right stick capacitive touch
+LGRIP: Left grip sense (Steam Controller)
+RGRIP: Right grip sense (Steam Controller)
 LMINI: Left mini shoulder button
 RMINI: Right mini shoulder button
 MISC1, MISC2, MISC3, MISC4, MISC5, MISC6: Additional buttons that vary by controller
+LTP_TOUCH: Left trackpad touch (dual trackpad controllers)
+RTP_TOUCH: Right trackpad touch (dual trackpad controllers)
+LTP_CAPTURE: Left trackpad click (dual trackpad controllers)
+RTP_CAPTURE: Right trackpad click (dual trackpad controllers)
 ```
 
 These can all be mapped to the following keyboard and mouse inputs:
@@ -969,7 +976,7 @@ The touchstick center is always the point of contact. As such, one can easily co
 The touch stick differs from other input methods in one particular way. The four stick directions cannot be used as a chord for other buttons, but you can chord the four direction with the grid buttons. As such, you can control two touch sticks at the same time on either side of the touch pad with each having different bindings. The example below showcases the numbers 1 to 4 bound to swipe gestures on the left half of the pad, and 5 to 8 bound to swipe gestures on the right half of the pad.
 
 ```
-TOUCH_STICK_MODE = GRID_AND_STICK
+TOUCHPAD_MODE = GRID_AND_STICK
 GRID_SIZE = 2 1 # Left and Right
 TOUCH_STICK_RADIUS = 800 # Use a larger value to use stick as swipe gestures
 
@@ -982,6 +989,57 @@ T2,TLEFT = 5
 T2,TUP = 6
 T2,TRIGHT = 7
 T2,TDOWN = 8
+```
+
+#### 8.2 Dual Trackpads
+
+Controllers with both left and right trackpads (e.g. Steam Controller) use trackpad buttons and settings that begin with ```LTP``` and ```RTP```. Otherwise, the usage is the same as described above.
+
+Example:
+```
+# Left trackpad
+LTP_MODE = GRID_AND_STICK
+LTP_STICK_RADIUS = 800 # Use a larger value to use stick as swipe gestures
+
+LTP_LEFT = 1
+LTP_UP = 2
+LTP_RIGHT = 3
+LTP_DOWN = 4
+
+# Right trackpad
+RTP_MODE = MOUSE
+RTP_SENS = 1 0.5 # Lower vertical sensitivity
+```
+
+The following tables summarize the left/right trackpad buttons and settings along with their touchpad counterparts.
+
+Buttons:
+```
+Left Trackpad    Right Trackpad    Single Touchpad
+
+LTP_TOUCH        RTP_TOUCH         TOUCH
+LTP_CAPTURE      RTP_CAPTURE       CAPTURE
+LTP_UP           RTP_UP            TUP
+LTP_DOWN         RTP_DOWN          TDOWN
+LTP_LEFT         RTP_LEFT          TLEFT
+LTP_RIGHT        RTP_RIGHT         TRIGHT
+LTP_RING         RTP_RING          TRING
+LTP1-LTP25       RTP1-RTP25        T1-T25
+```
+
+Settings:
+```
+Left Trackpad          Right Trackpad         Single Touchpad
+
+LTP_DUAL_STAGE_MODE    RTP_DUAL_STAGE_MODE    TOUCHPAD_DUAL_STAGE_MODE
+LTP_MODE               RTP_MODE               TOUCHPAD_MODE
+LTP_GRID_SIZE          RTP_GRID_SIZE          GRID_SIZE
+LTP_SENS               RTP_SENS               TOUCHPAD_SENS
+LTP_STICK_MODE         RTP_STICK_MODE         TOUCH_STICK_MODE
+LTP_DEADZONE_INNER     RTP_DEADZONE_INNER     TOUCH_DEADZONE_INNER
+LTP_RING_MODE          RTP_RING_MODE          TOUCH_RING_MODE
+LTP_STICK_RADIUS       RTP_STICK_RADIUS       TOUCH_STICK_RADIUS
+LTP_STICK_AXIS         RTP_STICK_AXIS         TOUCH_STICK_AXIS
 ```
 
 ### 9. Miscellaneous Commands

--- a/JoyShockMapper/CMakeLists.txt
+++ b/JoyShockMapper/CMakeLists.txt
@@ -186,10 +186,32 @@ if(SDL OR NOT DEFINED SDL)
     set(SDL_TEST_LIBRARY OFF)
     set(SDL_SHARED ON)
     set(SDL_TEST OFF)
+
+    # Build with libusb support for Switch 2 controllers
+    set(SDL_HIDAPI_LIBUSB ON)
+    set(SDL_HIDAPI_LIBUSB_SHARED OFF)
+
+    # Disable unused subsystems
+    set(SDL_AUDIO OFF)
+    set(SDL_CAMERA OFF)
+    set(SDL_DIALOG OFF)
+    set(SDL_GPU OFF)
+    set(SDL_HAPTIC OFF)
+    set(SDL_OFFSCREEN OFF)
+    set(SDL_POWER OFF)
+    set(SDL_RENDER OFF)
+    set(SDL_SENSOR OFF)
+    set(SDL_TRAY OFF)
+    set(SDL_VIDEO OFF)
+    set(SDL_VIRTUAL_JOYSTICK OFF)
+
+    # Set GIT_TAG to a recent main branch commit hash for full Steam Controller,
+    # Steam Deck, and Horipad support. Required until 3.6.0 is released.
 	CPMAddPackage (
 		NAME SDL3
         GITHUB_REPOSITORY libsdl-org/SDL
-        GIT_TAG release-3.4.4
+        #GIT_TAG release-3.6.0
+        GIT_TAG e7b238a6ed9d64bcc92f8ffc75fecc10f0153b73
 	)
 	set_target_properties(SDL_uclibc PROPERTIES FOLDER "SDL")
     set_target_properties(SDL3-shared PROPERTIES FOLDER "SDL")

--- a/JoyShockMapper/include/JoyShock.h
+++ b/JoyShockMapper/include/JoyShock.h
@@ -49,6 +49,8 @@ public:
 	void processStick(float stickX, float stickY, Stick &stick, float mouseCalibrationFactor, float deltaTime, bool &anyStickInput, bool &lockMouse, float &camSpeedX, float &camSpeedY);
 
 	void handleTouchStickChange(TouchStick &ts, bool down, short movX, short movY, float delta_time);
+	void handleLeftTouchStickChange(LeftTouchStick &ts, bool down, short movX, short movY, float delta_time);
+	void handleRightTouchStickChange(RightTouchStick &ts, bool down, short movX, short movY, float delta_time);
 
 	bool hasVirtualController();
 
@@ -65,7 +67,7 @@ public:
 	void applyOneEuroFilter(float rawX, float rawY, float deltaTime, float &outX, float &outY);
 	void resetOneEuroFilter();
 
-	void handleButtonChange(ButtonID id, bool pressed, int touchpadID = -1);
+	void handleButtonChange(ButtonID id, bool pressed, int touchpadID = -1, int leftTrackpadID = -1, int rightTrackpadID = -1);
 
 	void handleTriggerChange(ButtonID softIndex, ButtonID fullIndex, TriggerMode mode, float position, AdaptiveTriggerSetting &trigger_rumble);
 
@@ -74,14 +76,18 @@ public:
 	// return true if it hits the outer deadzone
 	bool processDeadZones(float &x, float &y, float innerDeadzone, float outerDeadzone);
 
-	void updateGridSize();
+	void updateGridSize(ButtonID grid_start);
 
 	bool processGyroStick(float stickX, float stickY, float stickLength, StickMode stickMode, bool forceOutput);
 
 	shared_ptr<DigitalButton::Context> _context;
 	vector<DigitalButton> _buttons;
 	vector<DigitalButton> _gridButtons;
+	vector<DigitalButton> _leftGridButtons;
+	vector<DigitalButton> _rightGridButtons;
 	vector<TouchStick> _touchpads;
+	vector<LeftTouchStick> _leftTrackpads;
+	vector<RightTouchStick> _rightTrackpads;
 	chrono::steady_clock::time_point _timeNow;
 	shared_ptr<MotionIf> _motion;
 	int _handle;
@@ -137,6 +143,9 @@ private:
 
 	void sendRumble(int smallRumble, int bigRumble);
 
+	JSMButton *getMapping(ButtonID id);
+	DigitalButton *getDigitalButton(ButtonID id, int touchpadID = -1, int leftTrackpadID = -1, int rightTrackpadID = -1);
+
 	DigitalButton *getMatchingSimBtn(ButtonID index);
 	DigitalButton *getMatchingDiagBtn(ButtonID index, optional<MapIterator> &iter);
 
@@ -170,6 +179,8 @@ private:
 
 	vector<DstState> _triggerState; // State of analog triggers when skip mode is active
 	vector<deque<float>> _prevTriggerPosition;
+
+	void updateGridSizeEx(vector<JSMButton> &in_grid_mappings, vector<DigitalButton> &in_grid_buttons);
 };
 
 template<>

--- a/JoyShockMapper/include/JoyShock.h
+++ b/JoyShockMapper/include/JoyShock.h
@@ -48,9 +48,9 @@ public:
 	// These two large functions are defined further down
 	void processStick(float stickX, float stickY, Stick &stick, float mouseCalibrationFactor, float deltaTime, bool &anyStickInput, bool &lockMouse, float &camSpeedX, float &camSpeedY);
 
-	void handleTouchStickChange(TouchStick &ts, bool down, short movX, short movY, float delta_time);
-	void handleLeftTouchStickChange(LeftTouchStick &ts, bool down, short movX, short movY, float delta_time);
-	void handleRightTouchStickChange(RightTouchStick &ts, bool down, short movX, short movY, float delta_time);
+	void handleTouchStickChange(TouchStick &ts, bool down, float movX, float movY, float delta_time);
+	void handleLeftTouchStickChange(LeftTouchStick &ts, bool down, float movX, float movY, float delta_time);
+	void handleRightTouchStickChange(RightTouchStick &ts, bool down, float movX, float movY, float delta_time);
 
 	bool hasVirtualController();
 

--- a/JoyShockMapper/include/JoyShockMapper.h
+++ b/JoyShockMapper/include/JoyShockMapper.h
@@ -73,6 +73,8 @@ enum class ButtonID
 
 	LTOUCH,          // Left stick capacitive touch
 	RTOUCH,          // Right stick capacitive touch
+	LGRIP,           // Left grip sense (Steam Controller)
+	RGRIP,           // Right grip sense (Steam Controller)
 
 	LMINI,           // Left mini shoulder button
 	RMINI,           // Right mini shoulder button

--- a/JoyShockMapper/include/JoyShockMapper.h
+++ b/JoyShockMapper/include/JoyShockMapper.h
@@ -66,27 +66,50 @@ enum class ButtonID
 	MLEFT,
 	MRIGHT,
 	MRING,
-	TOUCH,   // Touch anywhere on the touchpad
-	LTOUCH,  // Left stick capacitive touch
-	RTOUCH,  // Right stick capacitive touch
-	LMINI,   // Left mini shoulder button
-	RMINI,   // Right mini shoulder button
-	MISC1,   // Additional button that varies by controller
-	MISC2,   // Additional button that varies by controller
-	MISC3,   // Additional button that varies by controller
-	MISC4,   // Additional button that varies by controller
-	MISC5,   // Additional button that varies by controller
-	MISC6,   // Additional button that varies by controller
-	ZLF,     // = FIRST_ANALOG_TRIGGER
-	CAPTURE, // Full press of touchpad touch + press
-	// insert more analog triggers here
-	ZRF,  // =  LAST_ANALOG_TRIGGER
 
-	TUP,
-	TDOWN,
-	TLEFT,
-	TRIGHT,
-	TRING,
+	TOUCH,           // Touch anywhere on the touchpad
+	LTP_TOUCH,       // Touch anywhere on the left trackpad
+	RTP_TOUCH,       // Touch anywhere on the right trackpad
+
+	LTOUCH,          // Left stick capacitive touch
+	RTOUCH,          // Right stick capacitive touch
+
+	LMINI,           // Left mini shoulder button
+	RMINI,           // Right mini shoulder button
+
+	MISC1,           // Additional button that varies by controller
+	MISC2,           // Additional button that varies by controller
+	MISC3,           // Additional button that varies by controller
+	MISC4,           // Additional button that varies by controller
+	MISC5,           // Additional button that varies by controller
+	MISC6,           // Additional button that varies by controller
+
+	ZLF,             // = FIRST_ANALOG_TRIGGER
+	CAPTURE,         // Full press of touchpad touch + press
+	LTP_CAPTURE,     // Full press of left trackpad touch + press
+	RTP_CAPTURE,     // Full press of right trackpad touch + press
+	//
+	// Insert more analog triggers here
+	//
+	ZRF,             // =  LAST_ANALOG_TRIGGER
+
+	TUP,             // Touchpad touchstick up
+	TDOWN,           // Touchpad touchstick down
+	TLEFT,           // Touchpad touchstick left
+	TRIGHT,          // Touchpad touchstick right
+	TRING,           // Touchpad touchstick ring
+
+	LTP_UP,          // Left trackpad touchstick up
+	LTP_DOWN,        // Left trackpad touchstick down
+	LTP_LEFT,        // Left trackpad touchstick left
+	LTP_RIGHT,       // Left trackpad touchstick right
+	LTP_RING,        // Left trackpad touchstick ring
+
+	RTP_UP,          // Right trackpad touchstick up
+	RTP_DOWN,        // Right trackpad touchstick down
+	RTP_LEFT,        // Right trackpad touchstick left
+	RTP_RIGHT,       // Right trackpad touchstick right
+	RTP_RING,        // Right trackpad touchstick ring
 
 	SIZE, // Not a button
 
@@ -115,8 +138,70 @@ enum class ButtonID
 	T22,
 	T23,
 	T24,
-	T25,
+	T25, // LAST_TOUCH_BUTTON
+	//
 	// Add as necessary...
+	//
+
+	// Virtual buttons configured on the left trackpad grid (see LTP_MODE and LTP_GRID_SIZE)
+	LTP1,  // FIRST_LTP_BUTTON
+	LTP2,
+	LTP3,
+	LTP4,
+	LTP5,
+	LTP6,
+	LTP7,
+	LTP8,
+	LTP9,
+	LTP10,
+	LTP11,
+	LTP12,
+	LTP13,
+	LTP14,
+	LTP15,
+	LTP16,
+	LTP17,
+	LTP18,
+	LTP19,
+	LTP20,
+	LTP21,
+	LTP22,
+	LTP23,
+	LTP24,
+	LTP25, // LAST_LTP_BUTTON
+	//
+	// Add as necessary...
+	//
+
+	// Virtual buttons configured on the right trackpad grid (see RTP_MODE and RTP_GRID_SIZE)
+	RTP1,  // FIRST_RTP_BUTTON
+	RTP2,
+	RTP3,
+	RTP4,
+	RTP5,
+	RTP6,
+	RTP7,
+	RTP8,
+	RTP9,
+	RTP10,
+	RTP11,
+	RTP12,
+	RTP13,
+	RTP14,
+	RTP15,
+	RTP16,
+	RTP17,
+	RTP18,
+	RTP19,
+	RTP20,
+	RTP21,
+	RTP22,
+	RTP23,
+	RTP24,
+	RTP25, // LAST_RTP_BUTTON
+	//
+	// Add as necessary...
+	//
 };
 
 // help strings for each button
@@ -268,15 +353,51 @@ enum class SettingID
 	RETURN_DEADZONE_ANGLE_CUTOFF,
 	TELEMETRY_ENABLED,
 	TELEMETRY_PORT,
+
+	LTP_DUAL_STAGE_MODE,      // Left trackpad dual stage mode (any of the analog trigger modes), LTP_TOUCH is soft press, LTP_CAPTURE is full press
+	LTP_MODE,                 // Left trackpad mode (GRID_AND_STICK or MOUSE)
+	LTP_GRID_SIZE,            // Left trackpad grid size (rows and columns), uses LTP1 through LTP25
+	LTP_SENS,                 // Left trackpad sensitivity in mouse mode
+	LTP_STICK_MODE,           // Left trackpad touchstick mode (any of the analog stick modes)
+	LTP_DEADZONE_INNER,       // Left trackpad touchstick inner deadzone
+	LTP_RING_MODE,            // Left trackpad touchstick ring type (INNER or OUTER)
+	LTP_STICK_RADIUS,         // Left trackpad touchstick radius size
+	LTP_STICK_AXIS,           // Left trackpad touchstick axis configuration (STANDARD or INVERTED)
+
+	RTP_DUAL_STAGE_MODE,      // Right trackpad dual stage mode (any of the analog trigger modes), RTP_TOUCH is soft press, RTP_CAPTURE is full press
+	RTP_MODE,                 // Right trackpad mode (GRID_AND_STICK or MOUSE)
+	RTP_GRID_SIZE,            // Right trackpad grid size (rows and columns), uses RTP1 through RTP25
+	RTP_SENS,                 // Right trackpad sensitivity in mouse mode
+	RTP_STICK_MODE,           // Right trackpad touchstick mode (any of the analog stick modes)
+	RTP_DEADZONE_INNER,       // Right trackpad touchstick inner deadzone
+	RTP_RING_MODE,            // Right trackpad touchstick ring type (INNER or OUTER)
+	RTP_STICK_RADIUS,         // Right trackpad touchstick radius size
+	RTP_STICK_AXIS,           // Right trackpad touchstick axis configuration (STANDARD or INVERTED)
 };
 
 // constexpr are like #define but with respect to typeness
 constexpr size_t MAX_NO_OF_TOUCH = 2; // Could be obtained from JSL?
 constexpr int MAPPING_SIZE = int(ButtonID::SIZE);
+
 constexpr int FIRST_ANALOG_TRIGGER = int(ButtonID::ZLF);
 constexpr int LAST_ANALOG_TRIGGER = int(ButtonID::ZRF);
-constexpr int FIRST_TOUCH_BUTTON = MAPPING_SIZE + 1;
 constexpr int NUM_ANALOG_TRIGGERS = int(LAST_ANALOG_TRIGGER) - int(FIRST_ANALOG_TRIGGER) + 1;
+
+// Virtual buttons configured on the touchpad grid
+constexpr ButtonID FIRST_TOUCH_BUTTON = ButtonID::T1;
+constexpr ButtonID LAST_TOUCH_BUTTON = ButtonID::T25;
+constexpr int NUM_TOUCH_BUTTONS = int(LAST_TOUCH_BUTTON) - int(FIRST_TOUCH_BUTTON) + 1;
+
+// Virtual buttons configured on the left trackpad grid
+constexpr ButtonID FIRST_LTP_BUTTON = ButtonID::LTP1;
+constexpr ButtonID LAST_LTP_BUTTON = ButtonID::LTP25;
+constexpr int NUM_LTP_BUTTONS = int(LAST_LTP_BUTTON) - int(FIRST_LTP_BUTTON) + 1;
+
+// Virtual buttons configured on the right trackpad grid
+constexpr ButtonID FIRST_RTP_BUTTON = ButtonID::RTP1;
+constexpr ButtonID LAST_RTP_BUTTON = ButtonID::RTP25;
+constexpr int NUM_RTP_BUTTONS = int(LAST_RTP_BUTTON) - int(FIRST_RTP_BUTTON) + 1;
+
 constexpr float MAGIC_TAP_DURATION = 40.0f;           // in milliseconds.
 constexpr float MAGIC_INSTANT_DURATION = 40.0f;       // in milliseconds
 constexpr float MAGIC_EXTENDED_TAP_DURATION = 500.0f; // in milliseconds

--- a/JoyShockMapper/include/JslWrapper.h
+++ b/JoyShockMapper/include/JslWrapper.h
@@ -183,6 +183,8 @@ inline bool operator!=(const AdaptiveTriggerSetting &lhs, const AdaptiveTriggerS
 #define JSMASK_MISC6 0x100000000
 #define JSMASK_LTP_CAPTURE 0x200000000
 #define JSMASK_RTP_CAPTURE 0x400000000
+#define JSMASK_LGRIP 0x800000000
+#define JSMASK_RGRIP 0x1000000000
 
 #define JSOFFSET_UP 0
 #define JSOFFSET_DOWN 1
@@ -223,6 +225,8 @@ inline bool operator!=(const AdaptiveTriggerSetting &lhs, const AdaptiveTriggerS
 #define JSOFFSET_MISC6 32
 #define JSOFFSET_LTP_CAPTURE 33
 #define JSOFFSET_RTP_CAPTURE 34
+#define JSOFFSET_LGRIP 35
+#define JSOFFSET_RGRIP 36
 
 // PS5 Player maps for the DS Player Lightbar
 #define DS5_PLAYER_1 = 4

--- a/JoyShockMapper/include/JslWrapper.h
+++ b/JoyShockMapper/include/JslWrapper.h
@@ -71,6 +71,9 @@ inline bool operator!=(const AdaptiveTriggerSetting &lhs, const AdaptiveTriggerS
 #define JS_TYPE_FLYDIGI_VADER4_PRO 21
 #define JS_TYPE_FLYDIGI_VADER5_PRO 22
 #define JS_TYPE_SWITCH2_PRO_CONTROLLER 23
+#define JS_TYPE_STEAM_CONTROLLER 24
+#define JS_TYPE_STEAM_DECK 25
+#define JS_TYPE_STEAM_CONTROLLER_TRITON 26
 
 #define JS_SPLIT_TYPE_LEFT 1
 #define JS_SPLIT_TYPE_RIGHT 2
@@ -87,6 +90,7 @@ inline bool operator!=(const AdaptiveTriggerSetting &lhs, const AdaptiveTriggerS
 #define JS_VENDOR_NINTENDO 0x057e
 #define JS_VENDOR_PDP 0x0e6f
 #define JS_VENDOR_POWERA 0x24c6
+#define JS_VENDOR_VALVE 0x28de
 
 // USB PID values
 #define JS_PRODUCT_UNKNOWN 0
@@ -112,6 +116,20 @@ inline bool operator!=(const AdaptiveTriggerSetting &lhs, const AdaptiveTriggerS
 #define JS_PRODUCT_XBOX_SERIES_X 0x0b12
 #define JS_PRODUCT_XBOX_SERIES_X_BLE 0x0b13
 #define JS_PRODUCT_XBOX_ONE_XBOXGIP_CONTROLLER 0x02ff
+
+// USB PID values (Valve)
+#define JS_PRODUCT_VALVE_STEAM_CONTROLLER_CHELL 0x1101
+#define JS_PRODUCT_VALVE_STEAM_CONTROLLER_D0G_WIRED 0x1102
+#define JS_PRODUCT_VALVE_STEAM_CONTROLLER_D0G_BT 0x1105
+#define JS_PRODUCT_VALVE_STEAM_CONTROLLER_D0G_BT2 0x1106
+#define JS_PRODUCT_VALVE_STEAM_CONTROLLER_WIRELESS 0x1142
+#define JS_PRODUCT_VALVE_STEAM_CONTROLLER_V2_HEADCRAB_WIRED 0x1201
+#define JS_PRODUCT_VALVE_STEAM_CONTROLLER_V2_HEADCRAB_BT 0x1202
+#define JS_PRODUCT_VALVE_STEAM_CONTROLLER_NEPTUNE 0x1205 // Steam Deck
+#define JS_PRODUCT_VALVE_STEAM_CONTROLLER_TRITON 0x1302
+#define JS_PRODUCT_VALVE_STEAM_CONTROLLER_TRITON_BLE 0x1303
+#define JS_PRODUCT_VALVE_STEAM_CONTROLLER_TRITON_PROTEUS 0x1304 // Dongle
+#define JS_PRODUCT_VALVE_STEAM_CONTROLLER_TRITON_NEREID 0x1305 // Dongle
 
 // Device bus definitions
 #define JS_HARDWARE_BUS_UNKNOWN 0x00
@@ -163,6 +181,8 @@ inline bool operator!=(const AdaptiveTriggerSetting &lhs, const AdaptiveTriggerS
 #define JSMASK_MISC4 0x40000000
 #define JSMASK_MISC5 0x80000000
 #define JSMASK_MISC6 0x100000000
+#define JSMASK_LTP_CAPTURE 0x200000000
+#define JSMASK_RTP_CAPTURE 0x400000000
 
 #define JSOFFSET_UP 0
 #define JSOFFSET_DOWN 1
@@ -201,6 +221,8 @@ inline bool operator!=(const AdaptiveTriggerSetting &lhs, const AdaptiveTriggerS
 #define JSOFFSET_MISC4 30
 #define JSOFFSET_MISC5 31
 #define JSOFFSET_MISC6 32
+#define JSOFFSET_LTP_CAPTURE 33
+#define JSOFFSET_RTP_CAPTURE 34
 
 // PS5 Player maps for the DS Player Lightbar
 #define DS5_PLAYER_1 = 4
@@ -258,6 +280,25 @@ typedef struct TOUCH_STATE
 
 #endif
 
+typedef struct finger_state_t
+{
+	bool enabled;
+	bool down;
+	float x;
+	float y;
+} finger_state_t;
+
+typedef struct trackpad_state_t
+{
+	bool enabled;
+	finger_state_t fingers[2];
+	ButtonID grid_start;
+	ButtonID grid_end;
+	SettingID mode;
+	SettingID grid_size;
+	SettingID mouse_sens;
+} trackpad_state_t;
+
 class JslWrapper
 {
 protected:
@@ -279,6 +320,7 @@ public:
 	virtual IMU_STATE GetIMUState(int deviceId) = 0;
 	virtual MOTION_STATE GetMotionState(int deviceId) = 0;
 	virtual TOUCH_STATE GetTouchState(int deviceId, bool previous = false) = 0;
+	virtual void GetTrackpadState(int deviceId, trackpad_state_t *trackpads_state) = 0;
 	virtual bool GetTouchpadDimension(int deviceId, int& sizeX, int& sizeY) = 0;
 	virtual uint64_t GetButtons(int deviceId) = 0;
 	virtual float GetLeftX(int deviceId) = 0;
@@ -294,9 +336,9 @@ public:
 	virtual float GetAccelY(int deviceId) = 0;
 	virtual float GetAccelZ(int deviceId) = 0;
 	virtual int GetTouchId(int deviceId, bool secondTouch = false) = 0;
-	virtual bool GetTouchDown(int deviceId, bool secondTouch = false) = 0;
-	virtual float GetTouchX(int deviceId, bool secondTouch = false) = 0;
-	virtual float GetTouchY(int deviceId, bool secondTouch = false) = 0;
+	virtual bool GetTouchDown(int deviceId, int touchpad, int finger) = 0;
+	virtual float GetTouchX(int deviceId, int touchpad, int finger) = 0;
+	virtual float GetTouchY(int deviceId, int touchpad, int finger) = 0;
 	virtual float GetStickStep(int deviceId) = 0;
 	virtual float GetTriggerStep(int deviceId) = 0;
 	virtual float GetPollRate(int deviceId) = 0;
@@ -309,6 +351,7 @@ public:
 	virtual void SetCalibrationOffset(int deviceId, float xOffset, float yOffset, float zOffset) = 0;
 	virtual void SetCallback(void (*callback)(int, JOY_SHOCK_STATE, JOY_SHOCK_STATE, IMU_STATE, IMU_STATE, float)) = 0;
 	virtual void SetTouchCallback(void (*callback)(int, TOUCH_STATE, TOUCH_STATE, float)) = 0;
+	virtual void SetTrackpadCallback(void (*callback)(int, const trackpad_state_t *, const trackpad_state_t *, float)) = 0;
 	virtual int GetControllerType(int deviceId) = 0;
 	virtual int GetControllerSplitType(int deviceId) = 0;
 	virtual int GetControllerVendor(int deviceId) = 0;

--- a/JoyShockMapper/include/Stick.h
+++ b/JoyShockMapper/include/Stick.h
@@ -13,6 +13,8 @@ protected:
 	DigitalButton* _negativeButton;
 	DigitalButton* _positiveButton;
 	int _touchpadId;
+	int _leftTrackpadId;
+	int _rightTrackpadId;
 	ButtonID _pressedBtn;
 
 public:
@@ -22,11 +24,13 @@ public:
 		, _negativeButton(nullptr)
 		, _positiveButton(nullptr)
 		, _touchpadId(-1)
+		, _leftTrackpadId(-1)
+		, _rightTrackpadId(-1)
 		, _pressedBtn(ButtonID::NONE)
 	{
 	}
 
-	void init(DigitalButton& negativeBtn, DigitalButton& positiveBtn, int touchpadId = -1);
+	void init(DigitalButton& negativeBtn, DigitalButton& positiveBtn, int touchpadId = -1, int _leftTrackpadId = -1, int _rightTrackpadId = -1);
 
 	inline bool isInitialized() const
 	{
@@ -71,6 +75,8 @@ struct Stick
 	ButtonID _upId;
 	ButtonID _downId;
 	int _touchpadIndex = -1;
+	int _leftTrackpadIndex = -1;
+	int _rightTrackpadIndex = -1;
 
 	// Flick stick
 	chrono::steady_clock::time_point started_flick;
@@ -117,3 +123,28 @@ struct TouchStick : public Stick
 	}
 };
 
+struct LeftTouchStick : public Stick
+{
+	FloatXY _currentLocation = { 0.f, 0.f };
+	bool _prevDown = false;
+	ScrollAxis verticalScroll;
+	map<ButtonID, DigitalButton> buttons;
+	LeftTouchStick(int index, shared_ptr<DigitalButton::Context> common, int handle);
+	inline bool wasDown() const
+	{
+		return _prevDown;
+	}
+};
+
+struct RightTouchStick : public Stick
+{
+	FloatXY _currentLocation = { 0.f, 0.f };
+	bool _prevDown = false;
+	ScrollAxis verticalScroll;
+	map<ButtonID, DigitalButton> buttons;
+	RightTouchStick(int index, shared_ptr<DigitalButton::Context> common, int handle);
+	inline bool wasDown() const
+	{
+		return _prevDown;
+	}
+};

--- a/JoyShockMapper/src/ButtonHelp.cpp
+++ b/JoyShockMapper/src/ButtonHelp.cpp
@@ -53,6 +53,8 @@ const map<ButtonID, string> buttonHelpMap{
 	{ ButtonID::TRING, "Touch ring binding, either inner or outer." },
 	{ ButtonID::LTOUCH, "Left stick capacitive touch" },
 	{ ButtonID::RTOUCH, "Right stick capacitive touch" },
+	{ ButtonID::LGRIP, "Left grip sense (Steam Controller)" },
+	{ ButtonID::RGRIP, "Right grip sense (Steam Controller)" },
 	{ ButtonID::LMINI, "Left mini shoulder button" },
 	{ ButtonID::RMINI, "Right mini shoulder button" },
 	{ ButtonID::MISC1, "Additional button that varies by controller" },

--- a/JoyShockMapper/src/ButtonHelp.cpp
+++ b/JoyShockMapper/src/ButtonHelp.cpp
@@ -61,6 +61,20 @@ const map<ButtonID, string> buttonHelpMap{
 	{ ButtonID::MISC4, "Additional button that varies by controller" },
 	{ ButtonID::MISC5, "Additional button that varies by controller" },
 	{ ButtonID::MISC6, "Additional button that varies by controller" },
+	{ ButtonID::LTP_TOUCH, "Left trackpad touch" },
+	{ ButtonID::LTP_CAPTURE, "Left trackpad click" },
+	{ ButtonID::LTP_UP, "Left trackpad touchstick up" },
+	{ ButtonID::LTP_DOWN, "Left trackpad touchstick down" },
+	{ ButtonID::LTP_LEFT, "Left trackpad touchstick left" },
+	{ ButtonID::LTP_RIGHT, "Left trackpad touchstick right" },
+	{ ButtonID::LTP_RING, "Left trackpad touchstick ring" },
+	{ ButtonID::RTP_TOUCH, "Right trackpad touch" },
+	{ ButtonID::RTP_CAPTURE, "Right trackpad click" },
+	{ ButtonID::RTP_UP, "Right trackpad touchstick up" },
+	{ ButtonID::RTP_DOWN, "Right trackpad touchstick down" },
+	{ ButtonID::RTP_LEFT, "Right trackpad touchstick left" },
+	{ ButtonID::RTP_RIGHT, "Right trackpad touchstick right" },
+	{ ButtonID::RTP_RING, "Right trackpad touchstick ring" },
 };
 
 map<int, ButtonID> nnm = { 

--- a/JoyShockMapper/src/DigitalButton.cpp
+++ b/JoyShockMapper/src/DigitalButton.cpp
@@ -6,7 +6,7 @@
 
 void DigitalButton::Context::updateChordStack(bool isPressed, ButtonID id)
 {
-	if (id < ButtonID::SIZE || id >= ButtonID::T1) // Can't chord touch stick _buttons
+	if (id < ButtonID::SIZE || id >= FIRST_TOUCH_BUTTON) // Can't chord touch stick _buttons
 	{
 		if (isPressed)
 		{

--- a/JoyShockMapper/src/JoyShock.cpp
+++ b/JoyShockMapper/src/JoyShock.cpp
@@ -1626,7 +1626,7 @@ void JoyShock::processStick(float stickX, float stickY, Stick &stick, float mous
 	}
 }
 
-void JoyShock::handleTouchStickChange(TouchStick &ts, bool down, short movX, short movY, float delta_time)
+void JoyShock::handleTouchStickChange(TouchStick &ts, bool down, float movX, float movY, float delta_time)
 {
 	float stickX = down ? clamp<float>((ts._currentLocation.x() + movX) / getSetting(SettingID::TOUCH_STICK_RADIUS), -1.f, 1.f) : 0.f;
 	float stickY = down ? clamp<float>((ts._currentLocation.y() - movY) / getSetting(SettingID::TOUCH_STICK_RADIUS), -1.f, 1.f) : 0.f;
@@ -1666,7 +1666,7 @@ void JoyShock::handleTouchStickChange(TouchStick &ts, bool down, short movX, sho
 	ts._prevDown = down;
 }
 
-void JoyShock::handleLeftTouchStickChange(LeftTouchStick &ts, bool down, short movX, short movY, float delta_time)
+void JoyShock::handleLeftTouchStickChange(LeftTouchStick &ts, bool down, float movX, float movY, float delta_time)
 {
 	float stickX = down ? clamp<float>((ts._currentLocation.x() + movX) / getSetting(SettingID::LTP_STICK_RADIUS), -1.0f, 1.0f) : 0.0f;
 	float stickY = down ? clamp<float>((ts._currentLocation.y() - movY) / getSetting(SettingID::LTP_STICK_RADIUS), -1.0f, 1.0f) : 0.0f;
@@ -1701,7 +1701,7 @@ void JoyShock::handleLeftTouchStickChange(LeftTouchStick &ts, bool down, short m
 	ts._prevDown = down;
 }
 
-void JoyShock::handleRightTouchStickChange(RightTouchStick &ts, bool down, short movX, short movY, float delta_time)
+void JoyShock::handleRightTouchStickChange(RightTouchStick &ts, bool down, float movX, float movY, float delta_time)
 {
 	float stickX = down ? clamp<float>((ts._currentLocation.x() + movX) / getSetting(SettingID::RTP_STICK_RADIUS), -1.0f, 1.0f) : 0.0f;
 	float stickY = down ? clamp<float>((ts._currentLocation.y() - movY) / getSetting(SettingID::RTP_STICK_RADIUS), -1.0f, 1.0f) : 0.0f;

--- a/JoyShockMapper/src/JoyShock.cpp
+++ b/JoyShockMapper/src/JoyShock.cpp
@@ -7,6 +7,8 @@
 extern shared_ptr<JslWrapper> jsl;
 extern vector<JSMButton> mappings;
 extern vector<JSMButton> grid_mappings;
+extern vector<JSMButton> left_grid_mappings;
+extern vector<JSMButton> right_grid_mappings;
 extern float os_mouse_speed;
 extern float last_flick_and_rotation;
 
@@ -72,12 +74,20 @@ JoyShock::JoyShock(int uniqueHandle, int controllerSplitType, shared_ptr<Digital
 	{
 		_touchpads.push_back(TouchStick(i, _context, _handle));
 	}
+
+	_leftTrackpads.push_back(LeftTouchStick(0, _context, _handle));
+	_rightTrackpads.push_back(RightTouchStick(0, _context, _handle));
+
 	_leftStick.scroll.init(_buttons[int(ButtonID::LLEFT)], _buttons[int(ButtonID::LRIGHT)]);
 	_rightStick.scroll.init(_buttons[int(ButtonID::RLEFT)], _buttons[int(ButtonID::RRIGHT)]);
 	_motionStick.scroll.init(_buttons[int(ButtonID::MLEFT)], _buttons[int(ButtonID::MRIGHT)]);
 	_touchScrollX.init(_touchpads[0].buttons.find(ButtonID::TLEFT)->second, _touchpads[0].buttons.find(ButtonID::TRIGHT)->second);
 	_touchScrollY.init(_touchpads[0].buttons.find(ButtonID::TUP)->second, _touchpads[0].buttons.find(ButtonID::TDOWN)->second);
-	updateGridSize();
+
+	updateGridSizeEx(grid_mappings, _gridButtons);
+	updateGridSizeEx(left_grid_mappings, _leftGridButtons);
+	updateGridSizeEx(right_grid_mappings, _rightGridButtons);
+
 	_touchpads[0].scroll.init(_touchpads[0].buttons.find(ButtonID::TLEFT)->second, _touchpads[0].buttons.find(ButtonID::TRIGHT)->second);
 	_touchpads[0].verticalScroll.init(_touchpads[0].buttons.find(ButtonID::TUP)->second, _touchpads[0].buttons.find(ButtonID::TDOWN)->second);
 }
@@ -261,14 +271,65 @@ AxisSignPair JoyShock::getSetting<AxisSignPair>(SettingID index)
 	throw invalid_argument(ss.str().c_str());
 }
 
+JSMButton *JoyShock::getMapping(ButtonID id)
+{
+	if (int(id) < mappings.size())
+	{
+		return &mappings[int(id)];
+	}
+	else if (id >= FIRST_RTP_BUTTON && int(id) - int(FIRST_RTP_BUTTON) < right_grid_mappings.size())
+	{
+		return &right_grid_mappings[int(id) - int(FIRST_RTP_BUTTON)];
+	}
+	else if (id >= FIRST_LTP_BUTTON && int(id) - int(FIRST_LTP_BUTTON) < left_grid_mappings.size())
+	{
+		return &left_grid_mappings[int(id) - int(FIRST_LTP_BUTTON)];
+	}
+	else if (id >= FIRST_TOUCH_BUTTON && int(id) - int(FIRST_TOUCH_BUTTON) < grid_mappings.size())
+	{
+		return &grid_mappings[int(id) - int(FIRST_TOUCH_BUTTON)];
+	}
+	return nullptr;
+}
+
+DigitalButton *JoyShock::getDigitalButton(ButtonID id, int touchpadID, int leftTrackpadID, int rightTrackpadID)
+{
+	if (int(id) < _buttons.size())
+	{
+		return &_buttons[int(id)];
+	}
+	else if (touchpadID >= 0 && touchpadID < _touchpads.size())
+	{
+		return &_touchpads[touchpadID].buttons.find(id)->second;
+	}
+	else if (leftTrackpadID >= 0 && leftTrackpadID < _leftTrackpads.size())
+	{
+		return &_leftTrackpads[leftTrackpadID].buttons.find(id)->second;
+	}
+	else if (rightTrackpadID >= 0 && rightTrackpadID < _rightTrackpads.size())
+	{
+		return &_rightTrackpads[rightTrackpadID].buttons.find(id)->second;
+	}
+	else if (id >= FIRST_RTP_BUTTON && int(id) - int(FIRST_RTP_BUTTON) < _rightGridButtons.size())
+	{
+		return &_rightGridButtons[int(id) - int(FIRST_RTP_BUTTON)];
+	}
+	else if (id >= FIRST_LTP_BUTTON && int(id) - int(FIRST_LTP_BUTTON) < _leftGridButtons.size())
+	{
+		return &_leftGridButtons[int(id) - int(FIRST_LTP_BUTTON)];
+	}
+	else if (id >= FIRST_TOUCH_BUTTON && int(id) - int(FIRST_TOUCH_BUTTON) < _gridButtons.size())
+	{
+		return &_gridButtons[int(id) - int(FIRST_TOUCH_BUTTON)];
+	}
+	return nullptr;
+}
+
 DigitalButton *JoyShock::getMatchingSimBtn(ButtonID index)
 {
-	JSMButton *mapping = int(index) < mappings.size()        ? &mappings[int(index)] :
-	  int(index) - FIRST_TOUCH_BUTTON < grid_mappings.size() ? &grid_mappings[int(index) - FIRST_TOUCH_BUTTON] :
-	                                                           nullptr;
-	DigitalButton *button1 = int(index) < mappings.size()    ? &_buttons[int(index)] :
-	  int(index) - FIRST_TOUCH_BUTTON < grid_mappings.size() ? &_gridButtons[int(index) - FIRST_TOUCH_BUTTON] :
-	                                                           nullptr;
+	JSMButton *mapping = getMapping(index);
+	DigitalButton *button1 = getDigitalButton(index);
+
 	if (!mapping)
 	{
 		CERR << "Cannot find the button " << index << '\n';
@@ -285,9 +346,7 @@ DigitalButton *JoyShock::getMatchingSimBtn(ButtonID index)
 		// of the _buttons has a third SimMap with this one. I don't know if it's worth solving though...
 		for (auto iter = mapping->getSimMapIter() ; iter ; ++iter)
 		{
-			DigitalButton *button2 = int(iter->first) < mappings.size()      ? &_buttons[int(iter->first)] :
-			  int(iter->first) - FIRST_TOUCH_BUTTON < grid_mappings.size() ? &_gridButtons[int(iter->first) - FIRST_TOUCH_BUTTON] :
-																				nullptr;
+			DigitalButton *button2 = getDigitalButton(iter->first);
 
 			if (!button2)
 			{
@@ -304,12 +363,9 @@ DigitalButton *JoyShock::getMatchingSimBtn(ButtonID index)
 
 DigitalButton *JoyShock::getMatchingDiagBtn(ButtonID index, optional<MapIterator> &iter)
 {
-	JSMButton *mapping = int(index) < mappings.size()        ? &mappings[int(index)] :
-	  int(index) - FIRST_TOUCH_BUTTON < grid_mappings.size() ? &grid_mappings[int(index) - FIRST_TOUCH_BUTTON] :
-	                                                           nullptr;
-	DigitalButton *button1 = int(index) < mappings.size()    ? &_buttons[int(index)] :
-	  int(index) - FIRST_TOUCH_BUTTON < grid_mappings.size() ? &_gridButtons[int(index) - FIRST_TOUCH_BUTTON] :
-	                                                           nullptr;
+	JSMButton *mapping = getMapping(index);
+	DigitalButton *button1 = getDigitalButton(index);
+
 	if (!mapping)
 	{
 		CERR << "Cannot find the button " << index << '\n';
@@ -325,10 +381,7 @@ DigitalButton *JoyShock::getMatchingDiagBtn(ButtonID index, optional<MapIterator
 			iter = mapping->getDiagMapIter();
 		for (; *iter; ++*iter)
 		{
-			int i = int((*iter)->first);
-			DigitalButton *button2 = i < mappings.size()    ? &_buttons[i] :
-			  i - FIRST_TOUCH_BUTTON < grid_mappings.size() ? &_gridButtons[i - FIRST_TOUCH_BUTTON] :
-			                                                                 nullptr;
+			DigitalButton *button2 = getDigitalButton((*iter)->first);
 
 			if (!button2)
 			{
@@ -518,16 +571,13 @@ void JoyShock::resetOneEuroFilter()
 	_oneEuroY.reset();
 }
 
-void JoyShock::handleButtonChange(ButtonID id, bool pressed, int touchpadID)
+void JoyShock::handleButtonChange(ButtonID id, bool pressed, int touchpadID, int leftTrackpadID, int rightTrackpadID)
 {
-	DigitalButton *button = int(id) <= LAST_ANALOG_TRIGGER ? &_buttons[int(id)] :
-	  touchpadID >= 0 && touchpadID < _touchpads.size()    ? &_touchpads[touchpadID].buttons.find(id)->second :
-	  id >= ButtonID::T1                                   ? &_gridButtons[int(id) - int(ButtonID::T1)] :
-	                                                         nullptr;
+	DigitalButton *button = getDigitalButton(id, touchpadID, leftTrackpadID, rightTrackpadID);
 
 	if (!button)
 	{
-		CERR << "Button " << id << " with tocuchpadId " << touchpadID << " could not be found\n";
+		CERR << "Button " << id << " could not be found (touchpadID: " << touchpadID << " leftTrackpadID: " << leftTrackpadID << " rightTrackpadID: " << rightTrackpadID << ")\n";
 		return;
 	}
 	else if ((!_context->nn && pressed) || (_context->nn > 0 && (id >= ButtonID::UP || id <= ButtonID::DOWN || id == ButtonID::S || id == ButtonID::E) && nnm.find(_context->nn) != nnm.end() && nnm.find(_context->nn)->second == id))
@@ -876,15 +926,38 @@ bool JoyShock::processDeadZones(float &x, float &y, float innerDeadzone, float o
 	return false;
 }
 
-void JoyShock::updateGridSize()
+void JoyShock::updateGridSizeEx(vector<JSMButton> &in_grid_mappings, vector<DigitalButton> &in_grid_buttons)
 {
-	while (_gridButtons.size() > grid_mappings.size())
-		_gridButtons.pop_back();
-
-	for (size_t i = _gridButtons.size(); i < grid_mappings.size(); ++i)
+	while (in_grid_buttons.size() > in_grid_mappings.size())
 	{
-		JSMButton &map(grid_mappings[i]);
-		_gridButtons.push_back(DigitalButton(_context, map));
+		in_grid_buttons.pop_back();
+	}
+
+	for (size_t i = in_grid_buttons.size(); i < in_grid_mappings.size(); ++i)
+	{
+		JSMButton &map(in_grid_mappings[i]);
+		in_grid_buttons.push_back(DigitalButton(_context, map));
+	}
+}
+
+void JoyShock::updateGridSize(ButtonID grid_start)
+{
+	switch (grid_start)
+	{
+		case FIRST_TOUCH_BUTTON:
+			updateGridSizeEx(grid_mappings, _gridButtons);
+			break;
+
+		case FIRST_LTP_BUTTON:
+			updateGridSizeEx(left_grid_mappings, _leftGridButtons);
+			break;
+
+		case FIRST_RTP_BUTTON:
+			updateGridSizeEx(right_grid_mappings, _rightGridButtons);
+			break;
+
+		default:
+			break;
 	}
 }
 
@@ -1151,7 +1224,7 @@ void JoyShock::processStick(float stickX, float stickY, Stick &stick, float mous
 
 	bool ring = ringMode == RingMode::INNER && stickLength > 0.0f && stickLength < 0.7f ||
 	  ringMode == RingMode::OUTER && stickLength > 0.7f;
-	handleButtonChange(stick._ringId, ring, stick._touchpadIndex);
+	handleButtonChange(stick._ringId, ring, stick._touchpadIndex, stick._leftTrackpadIndex, stick._rightTrackpadIndex);
 
 	if (stick.ignore_stick_mode && stickMode == StickMode::INVALID && stickX == 0 && stickY == 0)
 	{
@@ -1243,13 +1316,13 @@ void JoyShock::processStick(float stickX, float stickY, Stick &stick, float mous
 	else if (stickMode == StickMode::NO_MOUSE || stickMode == StickMode::INNER_RING || stickMode == StickMode::OUTER_RING)
 	{ // Do not do if invalid
 		// left!
-		handleButtonChange(stick._leftId, left, stick._touchpadIndex);
+		handleButtonChange(stick._leftId, left, stick._touchpadIndex, stick._leftTrackpadIndex, stick._rightTrackpadIndex);
 		// right!
-		handleButtonChange(stick._rightId, right, stick._touchpadIndex);
+		handleButtonChange(stick._rightId, right, stick._touchpadIndex, stick._leftTrackpadIndex, stick._rightTrackpadIndex);
 		// up!
-		handleButtonChange(stick._upId, up, stick._touchpadIndex);
+		handleButtonChange(stick._upId, up, stick._touchpadIndex, stick._leftTrackpadIndex, stick._rightTrackpadIndex);
 		// down!
-		handleButtonChange(stick._downId, down, stick._touchpadIndex);
+		handleButtonChange(stick._downId, down, stick._touchpadIndex, stick._leftTrackpadIndex, stick._rightTrackpadIndex);
 
 		anyStickInput = left || right || up || down; // ring doesn't count
 	}
@@ -1575,7 +1648,7 @@ void JoyShock::handleTouchStickChange(TouchStick &ts, bool down, short movX, sho
 	ts.lastX = stickX;
 	ts.lastY = stickY;
 
-	moveMouse(camSpeedX * float(getSetting<AxisSignPair>(SettingID::TOUCH_STICK_AXIS).first), -camSpeedY * float(getSetting<AxisSignPair>(SettingID::TOUCH_STICK_AXIS).second));
+	moveMouse(camSpeedX * float(axisSign.first), -camSpeedY * float(axisSign.second));
 
 	if (!down && ts._prevDown)
 	{
@@ -1583,6 +1656,76 @@ void JoyShock::handleTouchStickChange(TouchStick &ts, bool down, short movX, sho
 
 		ts.is_flicking = false;
 		ts.acceleration = 1.0;
+		ts.ignore_stick_mode = false;
+	}
+	else
+	{
+		ts._currentLocation = { ts._currentLocation.x() + movX, ts._currentLocation.y() - movY };
+	}
+
+	ts._prevDown = down;
+}
+
+void JoyShock::handleLeftTouchStickChange(LeftTouchStick &ts, bool down, short movX, short movY, float delta_time)
+{
+	float stickX = down ? clamp<float>((ts._currentLocation.x() + movX) / getSetting(SettingID::LTP_STICK_RADIUS), -1.0f, 1.0f) : 0.0f;
+	float stickY = down ? clamp<float>((ts._currentLocation.y() - movY) / getSetting(SettingID::LTP_STICK_RADIUS), -1.0f, 1.0f) : 0.0f;
+	float mouseCalibrationFactor = 180.0f / M_PI / os_mouse_speed;
+	bool anyStickInput = false;
+	bool lockMouse = false;
+	float camSpeedX = 0.0f;
+	float camSpeedY = 0.0f;
+	auto axisSign = getSetting<AxisSignPair>(SettingID::LTP_STICK_AXIS);
+
+	stickX *= float(axisSign.first);
+	stickY *= float(axisSign.second);
+	processStick(stickX, stickY, ts, mouseCalibrationFactor, delta_time, anyStickInput, lockMouse, camSpeedX, camSpeedY);
+	ts.lastX = stickX;
+	ts.lastY = stickY;
+
+	moveMouse(camSpeedX * float(axisSign.first), -camSpeedY * float(axisSign.second));
+
+	if (!down && ts._prevDown)
+	{
+		ts._currentLocation = { 0.0f, 0.0f };
+
+		ts.is_flicking = false;
+		ts.acceleration = 1.0f;
+		ts.ignore_stick_mode = false;
+	}
+	else
+	{
+		ts._currentLocation = { ts._currentLocation.x() + movX, ts._currentLocation.y() - movY };
+	}
+
+	ts._prevDown = down;
+}
+
+void JoyShock::handleRightTouchStickChange(RightTouchStick &ts, bool down, short movX, short movY, float delta_time)
+{
+	float stickX = down ? clamp<float>((ts._currentLocation.x() + movX) / getSetting(SettingID::RTP_STICK_RADIUS), -1.0f, 1.0f) : 0.0f;
+	float stickY = down ? clamp<float>((ts._currentLocation.y() - movY) / getSetting(SettingID::RTP_STICK_RADIUS), -1.0f, 1.0f) : 0.0f;
+	float mouseCalibrationFactor = 180.0f / M_PI / os_mouse_speed;
+	bool anyStickInput = false;
+	bool lockMouse = false;
+	float camSpeedX = 0.0f;
+	float camSpeedY = 0.0f;
+	auto axisSign = getSetting<AxisSignPair>(SettingID::RTP_STICK_AXIS);
+
+	stickX *= float(axisSign.first);
+	stickY *= float(axisSign.second);
+	processStick(stickX, stickY, ts, mouseCalibrationFactor, delta_time, anyStickInput, lockMouse, camSpeedX, camSpeedY);
+	ts.lastX = stickX;
+	ts.lastY = stickY;
+
+	moveMouse(camSpeedX * float(axisSign.first), -camSpeedY * float(axisSign.second));
+
+	if (!down && ts._prevDown)
+	{
+		ts._currentLocation = { 0.0f, 0.0f };
+
+		ts.is_flicking = false;
+		ts.acceleration = 1.0f;
 		ts.ignore_stick_mode = false;
 	}
 	else

--- a/JoyShockMapper/src/JoyShock.cpp
+++ b/JoyShockMapper/src/JoyShock.cpp
@@ -1543,7 +1543,7 @@ void JoyShock::processStick(float stickX, float stickY, Stick &stick, float mous
 					returnDeadzone2 = angleBasedDeadzone(angleEquivalent, returningDeadzone, returningCutoff);
 				}
 			}
-			float returnDeadzone = min({ returnDeadzone1, returnDeadzone2 });
+			float returnDeadzone = min(returnDeadzone1, returnDeadzone2);
 			outputX *= returnDeadzone;
 			outputY *= returnDeadzone;
 			if (returnDeadzone == 0.f)

--- a/JoyShockMapper/src/JslWrapper.cpp
+++ b/JoyShockMapper/src/JslWrapper.cpp
@@ -56,6 +56,11 @@ public:
 		return JslGetTouchState(deviceId, previous);
 	}
 
+	void GetTrackpadState(int deviceId, trackpad_state_t *trackpads_state) override
+	{
+		// Not supported by JSL.
+	}
+
 	bool GetTouchpadDimension(int deviceId, int& sizeX, int& sizeY) override
 	{
 		return JslGetTouchpadDimension(deviceId, sizeX, sizeY);
@@ -131,19 +136,19 @@ public:
 		return JslGetTouchId(deviceId, secondTouch);
 	}
 
-	bool GetTouchDown(int deviceId, bool secondTouch = false) override
+	bool GetTouchDown(int deviceId, int touchpad, int finger) override
 	{
-		return JslGetTouchDown(deviceId, secondTouch);
+		return JslGetTouchDown(deviceId, (finger != 0));
 	}
 
-	float GetTouchX(int deviceId, bool secondTouch = false) override
+	float GetTouchX(int deviceId, int touchpad, int finger) override
 	{
-		return JslGetTouchX(deviceId, secondTouch);
+		return JslGetTouchX(deviceId, (finger != 0));
 	}
 
-	float GetTouchY(int deviceId, bool secondTouch = false) override
+	float GetTouchY(int deviceId, int touchpad, int finger) override
 	{
-		return JslGetTouchY(deviceId, secondTouch);
+		return JslGetTouchY(deviceId, (finger != 0));
 	}
 
 	float GetStickStep(int deviceId) override
@@ -204,6 +209,11 @@ public:
 	void SetTouchCallback(void (*callback)(int, TOUCH_STATE, TOUCH_STATE, float)) override
 	{
 		JslSetTouchCallback(callback);
+	}
+
+	void SetTrackpadCallback(void (*callback)(int, const trackpad_state_t *, const trackpad_state_t *, float)) override
+	{
+		// Not supported by JSL.
 	}
 
 	int GetControllerType(int deviceId) override

--- a/JoyShockMapper/src/SDLWrapper.cpp
+++ b/JoyShockMapper/src/SDLWrapper.cpp
@@ -822,10 +822,14 @@ public:
 			switch (_controllerMap[deviceId]->_ctrlr_type)
 			{
 			case JS_TYPE_DS4:
-			case JS_TYPE_DS:
 				// Matching SDL resolution
 				sizeX = 1920;
 				sizeY = 920;
+				break;
+			case JS_TYPE_DS:
+				// Matching SDL resolution
+				sizeX = 1920;
+				sizeY = 1070;
 				break;
 			case JS_TYPE_STEAM_CONTROLLER:
 				// Steam Controller (2015) has dual 40 mm trackpads, but the

--- a/JoyShockMapper/src/SDLWrapper.cpp
+++ b/JoyShockMapper/src/SDLWrapper.cpp
@@ -920,14 +920,13 @@ public:
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2) ? 1ULL << JSOFFSET_SR : 0;
 			break;
 		case JS_TYPE_HORI_STEAM:
-			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC1) ? 1ULL << JSOFFSET_MISC1 : 0;       // QAM button ("..." button)
-			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1) ? 1ULL << JSOFFSET_SR : 0;  // R4 back button
-			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_LEFT_PADDLE1) ? 1ULL << JSOFFSET_SL : 0;   // L4 back button
-			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2) ? 1ULL << JSOFFSET_FNR : 0; // M2 button below right stick
-			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_LEFT_PADDLE2) ? 1ULL << JSOFFSET_FNL : 0;  // M1 button below left stick
-			// TODO: Left/right capacitive touch sticks
-			//buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC3) ? 1ULL << JSOFFSET_LTOUCH : 0;      // Left stick capacitive touch
-			//buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC4) ? 1ULL << JSOFFSET_RTOUCH : 0;      // Right stick capacitive touch
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC1) ? 1ULL << JSOFFSET_MISC1 : 0;            // QAM button ("..." button)
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1) ? 1ULL << JSOFFSET_SR : 0;       // R4 back button
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_LEFT_PADDLE1) ? 1ULL << JSOFFSET_SL : 0;        // L4 back button
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2) ? 1ULL << JSOFFSET_FNR : 0;      // M2 button below right stick
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_LEFT_PADDLE2) ? 1ULL << JSOFFSET_FNL : 0;       // M1 button below left stick
+			buttons |= SDL_GetGamepadCapSense(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_CAPSENSE_LEFT_STICK) ? 1ULL << JSOFFSET_LTOUCH : 0;  // Left stick capacitive touch
+			buttons |= SDL_GetGamepadCapSense(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_CAPSENSE_RIGHT_STICK) ? 1ULL << JSOFFSET_RTOUCH : 0; // Right stick capacitive touch
 			break;
 		case JS_TYPE_G7_PRO_8K:
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC1) ? 1ULL << JSOFFSET_CAPTURE : 0;     // Share button
@@ -987,14 +986,15 @@ public:
 			// TODO: Left/right grip sense
 			// Fall through.
 		case JS_TYPE_STEAM_DECK:
-			// TODO: Left/right capacitive touch sticks
-			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC1) ? 1ULL << JSOFFSET_MISC1 : 0;          // QAM button ("..." button)
-			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1) ? 1ULL << JSOFFSET_SR : 0;     // R4 back button
-			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_LEFT_PADDLE1) ? 1ULL << JSOFFSET_SL : 0;      // L4 back button
-			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2) ? 1ULL << JSOFFSET_FNR : 0;    // R5 back button
-			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_LEFT_PADDLE2) ? 1ULL << JSOFFSET_FNL : 0;     // L5 back button
-			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_TOUCHPAD) ? 1ULL << JSOFFSET_LTP_CAPTURE : 0; // Left trackpad click
-			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC2) ? 1ULL << JSOFFSET_RTP_CAPTURE : 0;    // Right trackpad click
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC1) ? 1ULL << JSOFFSET_MISC1 : 0;              // QAM button ("..." button)
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1) ? 1ULL << JSOFFSET_SR : 0;         // R4 back button
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_LEFT_PADDLE1) ? 1ULL << JSOFFSET_SL : 0;          // L4 back button
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2) ? 1ULL << JSOFFSET_FNR : 0;        // R5 back button
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_LEFT_PADDLE2) ? 1ULL << JSOFFSET_FNL : 0;         // L5 back button
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_TOUCHPAD) ? 1ULL << JSOFFSET_LTP_CAPTURE : 0;     // Left trackpad click
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC2) ? 1ULL << JSOFFSET_RTP_CAPTURE : 0;        // Right trackpad click
+			buttons |= SDL_GetGamepadCapSense(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_CAPSENSE_LEFT_STICK) ? 1ULL << JSOFFSET_LTOUCH : 0;    // Left stick capacitive touch
+			buttons |= SDL_GetGamepadCapSense(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_CAPSENSE_RIGHT_STICK) ? 1ULL << JSOFFSET_RTOUCH : 0;   // Right stick capacitive touch
 			break;
 		default:
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC1) ? 1ULL << JSOFFSET_MISC1 : 0;

--- a/JoyShockMapper/src/SDLWrapper.cpp
+++ b/JoyShockMapper/src/SDLWrapper.cpp
@@ -58,8 +58,10 @@ struct ControllerDevice
 	  , _vendorId(JS_VENDOR_UNKNOWN)
 	  , _productId(JS_PRODUCT_UNKNOWN)
 	{
-		_prevTouchState.t0Down = false;
-		_prevTouchState.t1Down = false;
+		_has_trackpads = false;
+		memset(_trackpads_state, 0, sizeof(_trackpads_state));
+		memset(_prev_trackpads_state, 0, sizeof(_prev_trackpads_state));
+
 		if (SDL_IsGamepad(id))
 		{
 			_sdlController = nullptr;
@@ -84,6 +86,64 @@ struct ControllerDevice
 					if (_has_accel)
 					{
 						SDL_SetGamepadSensorEnabled(_sdlController, SDL_SENSOR_ACCEL, true);
+					}
+
+					// Initialize touchpads/trackpads
+					int num_trackpads = SDL_GetNumGamepadTouchpads(_sdlController);
+					num_trackpads = clamp(num_trackpads, 0, 2);
+					if (num_trackpads > 0)
+					{
+						// Two configurations supported:
+						// 1. One touchpad, up to two fingers simultaneously.
+						// 2. Two trackpads, only one finger per trackpad.
+						const int max_fingers = (num_trackpads == 1 ? 2 : 1);
+						for (int i = 0; i < num_trackpads; i++)
+						{
+							int num_fingers = SDL_GetNumGamepadTouchpadFingers(_sdlController, i);
+							num_fingers = clamp(num_fingers, 0, max_fingers);
+							if (num_fingers > 0)
+							{
+								_has_trackpads = true;
+								_trackpads_state[i].enabled = true;
+								for (int j = 0; j < num_fingers; j++)
+								{
+									_trackpads_state[i].fingers[j].enabled = true;
+								}
+							}
+						}
+
+						if (_has_trackpads)
+						{
+							if (num_trackpads == 2)
+							{
+								// Left trackpad settings
+								trackpad_state_t *left_trackpad = &_trackpads_state[0];
+								left_trackpad->grid_start = FIRST_LTP_BUTTON;
+								left_trackpad->grid_end = LAST_LTP_BUTTON;
+								left_trackpad->mode = SettingID::LTP_MODE;
+								left_trackpad->grid_size = SettingID::LTP_GRID_SIZE;
+								left_trackpad->mouse_sens = SettingID::LTP_SENS;
+
+								// Right trackpad settings
+								trackpad_state_t *right_trackpad = &_trackpads_state[1];
+								right_trackpad->grid_start = FIRST_RTP_BUTTON;
+								right_trackpad->grid_end = LAST_RTP_BUTTON;
+								right_trackpad->mode = SettingID::RTP_MODE;
+								right_trackpad->grid_size = SettingID::RTP_GRID_SIZE;
+								right_trackpad->mouse_sens = SettingID::RTP_SENS;
+							}
+							else // num_trackpads == 1
+							{
+								// Touchpad settings
+								trackpad_state_t *touchpad = &_trackpads_state[0];
+								touchpad->grid_start = FIRST_TOUCH_BUTTON;
+								touchpad->grid_end = LAST_TOUCH_BUTTON;
+								touchpad->mode = SettingID::TOUCHPAD_MODE;
+								touchpad->grid_size = SettingID::GRID_SIZE;
+								touchpad->mouse_sens = SettingID::TOUCHPAD_SENS;
+							}
+							memcpy(_prev_trackpads_state, _trackpads_state, sizeof(_prev_trackpads_state));
+						}
 					}
 
 					_vendorId = SDL_GetGamepadVendor(_sdlController);
@@ -165,6 +225,29 @@ struct ControllerDevice
 						if (_productId == JS_PRODUCT_NINTENDO_SWITCH2_PRO)
 						{
 							_ctrlr_type = JS_TYPE_SWITCH2_PRO_CONTROLLER;
+						}
+						break;
+					case JS_VENDOR_VALVE:
+						switch (_productId)
+						{
+						case JS_PRODUCT_VALVE_STEAM_CONTROLLER_CHELL:
+						case JS_PRODUCT_VALVE_STEAM_CONTROLLER_D0G_WIRED:
+						case JS_PRODUCT_VALVE_STEAM_CONTROLLER_D0G_BT:
+						case JS_PRODUCT_VALVE_STEAM_CONTROLLER_D0G_BT2:
+						case JS_PRODUCT_VALVE_STEAM_CONTROLLER_WIRELESS:
+						case JS_PRODUCT_VALVE_STEAM_CONTROLLER_V2_HEADCRAB_WIRED:
+						case JS_PRODUCT_VALVE_STEAM_CONTROLLER_V2_HEADCRAB_BT:
+							_ctrlr_type = JS_TYPE_STEAM_CONTROLLER;
+							break;
+						case JS_PRODUCT_VALVE_STEAM_CONTROLLER_NEPTUNE:
+							_ctrlr_type = JS_TYPE_STEAM_DECK;
+							break;
+						case JS_PRODUCT_VALVE_STEAM_CONTROLLER_TRITON:
+						case JS_PRODUCT_VALVE_STEAM_CONTROLLER_TRITON_BLE:
+						case JS_PRODUCT_VALVE_STEAM_CONTROLLER_TRITON_PROTEUS:
+						case JS_PRODUCT_VALVE_STEAM_CONTROLLER_TRITON_NEREID:
+							_ctrlr_type = JS_TYPE_STEAM_CONTROLLER_TRITON;
+							break;
 						}
 						break;
 					}
@@ -323,7 +406,9 @@ public:
 	AdaptiveTriggerSetting _rightTriggerEffect;
 	uint8_t _micLight = 0;
 	SDL_Gamepad *_sdlController = nullptr;
-	TOUCH_STATE _prevTouchState;
+	bool _has_trackpads;
+	trackpad_state_t _trackpads_state[2];
+	trackpad_state_t _prev_trackpads_state[2];
 };
 
 struct SdlInstance : public JslWrapper
@@ -527,11 +612,11 @@ public:
 					memset(&dummy2, 0, sizeof(dummy2));
 					g_callback(iter->first, dummy1, dummy1, dummy2, dummy2, tick_time);
 				}
-				if (g_touch_callback)
+				if (g_trackpad_callback && iter->second->_has_trackpads)
 				{
-					TOUCH_STATE touch = GetTouchState(iter->first, false);
-					g_touch_callback(iter->first, touch, iter->second->_prevTouchState, tick_time);
-					iter->second->_prevTouchState = touch;
+					GetTrackpadState(iter->first, iter->second->_trackpads_state);
+					g_trackpad_callback(iter->first, iter->second->_trackpads_state, iter->second->_prev_trackpads_state, tick_time);
+					memcpy(iter->second->_prev_trackpads_state, iter->second->_trackpads_state, sizeof(iter->second->_prev_trackpads_state));
 				}
 				// Perform rumble
 				SDL_RumbleGamepad(iter->second->_sdlController, iter->second->_big_rumble, iter->second->_small_rumble, Uint32(tick_time + 5));
@@ -544,7 +629,7 @@ public:
 	SDL_JoystickID * _joysticksArray = nullptr;
 	map<int, ControllerDevice *> _controllerMap;
 	void (*g_callback)(int, JOY_SHOCK_STATE, JOY_SHOCK_STATE, IMU_STATE, IMU_STATE, float) = nullptr;
-	void (*g_touch_callback)(int, TOUCH_STATE, TOUCH_STATE, float) = nullptr;
+	void (*g_trackpad_callback)(int, const trackpad_state_t *, const trackpad_state_t *, float) = nullptr;
 	atomic_bool keep_polling = false;
 	mutex controller_lock;
 
@@ -654,7 +739,7 @@ public:
 		lock_guard guard(controller_lock);
 		keep_polling = false;
 		g_callback = nullptr;
-		g_touch_callback = nullptr;
+		g_trackpad_callback = nullptr;
 		auto iter = _controllerMap.begin();
 		while (iter != _controllerMap.end())
 		{
@@ -703,22 +788,29 @@ public:
 
 	TOUCH_STATE GetTouchState(int deviceId, bool previous) override
 	{
+		// Only used by JSL.
 		TOUCH_STATE state;
-		memset(&state, 0, sizeof(TOUCH_STATE));
-
-		if (_controllerMap[deviceId] == nullptr ||
-			_controllerMap[deviceId]->_sdlController == nullptr ||
-			SDL_GetNumGamepadTouchpads(_controllerMap[deviceId]->_sdlController) <= 0)
-		{
-			return state;
-		}
-
-		if (!SDL_GetGamepadTouchpadFinger(_controllerMap[deviceId]->_sdlController, 0, 0, &state.t0Down, &state.t0X, &state.t0Y, nullptr) || 
-			!SDL_GetGamepadTouchpadFinger(_controllerMap[deviceId]->_sdlController, 0, 1, &state.t1Down, &state.t1X, &state.t1Y, nullptr))
-		{
-			CERR << "Cannot get finger state: " << SDL_GetError() << '\n';
-		}
+		memset(&state, 0, sizeof(state));
 		return state;
+	}
+
+	void GetTrackpadState(int deviceId, trackpad_state_t *trackpads_state) override
+	{
+		for (int i = 0; i < 2; i++)
+		{
+			trackpad_state_t *trackpad = &trackpads_state[i];
+			if (trackpad->enabled)
+			{
+				for (int j = 0; j < 2; j++)
+				{
+					finger_state_t *finger = &trackpad->fingers[j];
+					if (finger->enabled)
+					{
+						SDL_GetGamepadTouchpadFinger(_controllerMap[deviceId]->_sdlController, i, j, &finger->down, &finger->x, &finger->y, nullptr);
+					}
+				}
+			}
+		}
 	}
 
 	bool GetTouchpadDimension(int deviceId, int &sizeX, int &sizeY) override
@@ -734,6 +826,29 @@ public:
 				// Matching SDL resolution
 				sizeX = 1920;
 				sizeY = 920;
+				break;
+			case JS_TYPE_STEAM_CONTROLLER:
+				// Steam Controller (2015) has dual 40 mm trackpads, but the
+				// actual sensor diameter is 38 mm (see GlidePoint TM040040):
+				// https://www.cirque.com/glidepoint-circle-trackpads
+				// Scale the input to match a typical mouse:
+				// 800 counts/inch * 1 inch / 25.4 mm * 38 mm = 1196.9 counts
+				sizeX = 1197;
+				sizeY = 1197;
+				break;
+			case JS_TYPE_STEAM_DECK:
+				// Steam Deck has dual 32.5 mm trackpads.
+				// Scale the input to match a typical mouse:
+				// 800 counts/inch * 1 inch / 25.4 mm * 32.5 mm = 1023.6 counts
+				sizeX = 1024;
+				sizeY = 1024;
+				break;
+			case JS_TYPE_STEAM_CONTROLLER_TRITON:
+				// Steam Controller has dual 34.5 mm trackpads.
+				// Scale the input to match a typical mouse:
+				// 800 counts/inch * 1 inch / 25.4 mm * 34.5 mm = 1086.6 counts
+				sizeX = 1087;
+				sizeY = 1087;
 				break;
 			default:
 				sizeX = 0;
@@ -805,13 +920,14 @@ public:
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2) ? 1ULL << JSOFFSET_SR : 0;
 			break;
 		case JS_TYPE_HORI_STEAM:
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC1) ? 1ULL << JSOFFSET_MISC1 : 0;       // QAM button ("..." button)
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1) ? 1ULL << JSOFFSET_SR : 0;  // R4 back button
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_LEFT_PADDLE1) ? 1ULL << JSOFFSET_SL : 0;   // L4 back button
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2) ? 1ULL << JSOFFSET_FNR : 0; // M2 button below right stick
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_LEFT_PADDLE2) ? 1ULL << JSOFFSET_FNL : 0;  // M1 button below left stick
-			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC2) ? 1ULL << JSOFFSET_MISC1 : 0;       // QAM button ("..." button)
-			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC3) ? 1ULL << JSOFFSET_LTOUCH : 0;      // Left stick capacitive touch
-			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC4) ? 1ULL << JSOFFSET_RTOUCH : 0;      // Right stick capacitive touch
+			// TODO: Left/right capacitive touch sticks
+			//buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC3) ? 1ULL << JSOFFSET_LTOUCH : 0;      // Left stick capacitive touch
+			//buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC4) ? 1ULL << JSOFFSET_RTOUCH : 0;      // Right stick capacitive touch
 			break;
 		case JS_TYPE_G7_PRO_8K:
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC1) ? 1ULL << JSOFFSET_CAPTURE : 0;     // Share button
@@ -861,6 +977,24 @@ public:
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_LEFT_PADDLE2) ? 1ULL << JSOFFSET_FNL : 0;  // M4 back button (bottom left)
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC2) ? 1ULL << JSOFFSET_MISC1 : 0;       // C face button
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC3) ? 1ULL << JSOFFSET_MISC2 : 0;       // Z face button
+			break;
+		case JS_TYPE_STEAM_CONTROLLER:
+			// Only the back grip buttons are exposed by SDL3.
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1) ? 1ULL << JSOFFSET_SR : 0;   // Right back grip button
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_LEFT_PADDLE1) ? 1ULL << JSOFFSET_SL : 0;    // Left back grip button
+			break;
+		case JS_TYPE_STEAM_CONTROLLER_TRITON:
+			// TODO: Left/right grip sense
+			// Fall through.
+		case JS_TYPE_STEAM_DECK:
+			// TODO: Left/right capacitive touch sticks
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC1) ? 1ULL << JSOFFSET_MISC1 : 0;          // QAM button ("..." button)
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1) ? 1ULL << JSOFFSET_SR : 0;     // R4 back button
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_LEFT_PADDLE1) ? 1ULL << JSOFFSET_SL : 0;      // L4 back button
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2) ? 1ULL << JSOFFSET_FNR : 0;    // R5 back button
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_LEFT_PADDLE2) ? 1ULL << JSOFFSET_FNL : 0;     // L5 back button
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_TOUCHPAD) ? 1ULL << JSOFFSET_LTP_CAPTURE : 0; // Left trackpad click
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC2) ? 1ULL << JSOFFSET_RTP_CAPTURE : 0;    // Right trackpad click
 			break;
 		default:
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC1) ? 1ULL << JSOFFSET_MISC1 : 0;
@@ -958,30 +1092,34 @@ public:
 		return int();
 	}
 
-	bool GetTouchDown(int deviceId, bool secondTouch)
+	bool GetTouchDown(int deviceId, int touchpad, int finger) override
 	{
-		bool touchState = 0;
-		return SDL_GetGamepadTouchpadFinger(_controllerMap[deviceId]->_sdlController, 0, secondTouch ? 1 : 0, &touchState, nullptr, nullptr, nullptr) ? touchState : false;
+		bool touchState = false;
+		if (SDL_GetGamepadTouchpadFinger(_controllerMap[deviceId]->_sdlController, touchpad, finger, &touchState, nullptr, nullptr, nullptr))
+		{
+			return touchState;
+		}
+		return false;
 	}
 
-	float GetTouchX(int deviceId, bool secondTouch = false) override
+	float GetTouchX(int deviceId, int touchpad, int finger) override
 	{
-		float x = 0;
-		if (SDL_GetGamepadTouchpadFinger(_controllerMap[deviceId]->_sdlController, 0, secondTouch ? 1 : 0, nullptr, nullptr, &x, nullptr))
+		float x = 0.0f;
+		if (SDL_GetGamepadTouchpadFinger(_controllerMap[deviceId]->_sdlController, touchpad, finger, nullptr, nullptr, &x, nullptr))
 		{
 			return x;
 		}
-		return x;
+		return 0.0f;
 	}
 
-	float GetTouchY(int deviceId, bool secondTouch = false) override
+	float GetTouchY(int deviceId, int touchpad, int finger) override
 	{
-		float y = 0;
-		if (SDL_GetGamepadTouchpadFinger(_controllerMap[deviceId]->_sdlController, 0, secondTouch ? 1 : 0, nullptr, nullptr, &y, nullptr))
+		float y = 0.0f;
+		if (SDL_GetGamepadTouchpadFinger(_controllerMap[deviceId]->_sdlController, touchpad, finger, nullptr, nullptr, &y, nullptr))
 		{
 			return y;
 		}
-		return y;
+		return 0.0f;
 	}
 
 	float GetStickStep(int deviceId) override
@@ -1037,8 +1175,13 @@ public:
 
 	void SetTouchCallback(void (*callback)(int, TOUCH_STATE, TOUCH_STATE, float)) override
 	{
+		// Only used by JSL.
+	}
+
+	void SetTrackpadCallback(void (*callback)(int, const trackpad_state_t *, const trackpad_state_t *, float)) override
+	{
 		lock_guard guard(controller_lock);
-		g_touch_callback = callback;
+		g_trackpad_callback = callback;
 	}
 
 	int GetControllerType(int deviceId) override

--- a/JoyShockMapper/src/SDLWrapper.cpp
+++ b/JoyShockMapper/src/SDLWrapper.cpp
@@ -843,8 +843,8 @@ public:
 		case JS_TYPE_FLYDIGI_APEX5:
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1) ? 1ULL << JSOFFSET_SR : 0;  // M1 back button (top right)
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_LEFT_PADDLE1) ? 1ULL << JSOFFSET_SL : 0;   // M2 back button (top left)
-			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2) ? 1ULL << JSOFFSET_FNR : 0; // M3 back button (bottom left)
-			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_LEFT_PADDLE2) ? 1ULL << JSOFFSET_FNL : 0;  // M4 back button (bottom right)
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2) ? 1ULL << JSOFFSET_FNR : 0; // M3 back button (bottom right)
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_LEFT_PADDLE2) ? 1ULL << JSOFFSET_FNL : 0;  // M4 back button (bottom left)
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC2) ? 1ULL << JSOFFSET_LMINI : 0;       // LM mini shoulder button
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC3) ? 1ULL << JSOFFSET_RMINI : 0;       // RM mini shoulder button
 			break;
@@ -857,8 +857,8 @@ public:
 		case JS_TYPE_FLYDIGI_VADER3_PRO:
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1) ? 1ULL << JSOFFSET_SR : 0;  // M1 back button (top right)
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_LEFT_PADDLE1) ? 1ULL << JSOFFSET_SL : 0;   // M2 back button (top left)
-			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2) ? 1ULL << JSOFFSET_FNR : 0; // M3 back button (bottom left)
-			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_LEFT_PADDLE2) ? 1ULL << JSOFFSET_FNL : 0;  // M4 back button (bottom right)
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2) ? 1ULL << JSOFFSET_FNR : 0; // M3 back button (bottom right)
+			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_LEFT_PADDLE2) ? 1ULL << JSOFFSET_FNL : 0;  // M4 back button (bottom left)
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC2) ? 1ULL << JSOFFSET_MISC1 : 0;       // C face button
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC3) ? 1ULL << JSOFFSET_MISC2 : 0;       // Z face button
 			break;

--- a/JoyShockMapper/src/SDLWrapper.cpp
+++ b/JoyShockMapper/src/SDLWrapper.cpp
@@ -983,7 +983,8 @@ public:
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_LEFT_PADDLE1) ? 1ULL << JSOFFSET_SL : 0;    // Left back grip button
 			break;
 		case JS_TYPE_STEAM_CONTROLLER_TRITON:
-			// TODO: Left/right grip sense
+			buttons |= SDL_GetGamepadCapSense(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_CAPSENSE_LEFT_GRIP) ? 1ULL << JSOFFSET_LGRIP : 0;    // Left grip sense
+			buttons |= SDL_GetGamepadCapSense(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_CAPSENSE_RIGHT_GRIP) ? 1ULL << JSOFFSET_RGRIP : 0;   // Right grip sense
 			// Fall through.
 		case JS_TYPE_STEAM_DECK:
 			buttons |= SDL_GetGamepadButton(_controllerMap[deviceId]->_sdlController, SDL_GAMEPAD_BUTTON_MISC1) ? 1ULL << JSOFFSET_MISC1 : 0;              // QAM button ("..." button)

--- a/JoyShockMapper/src/Stick.cpp
+++ b/JoyShockMapper/src/Stick.cpp
@@ -2,14 +2,15 @@
 #include "Stick.h"
 #include "JSMVariable.hpp"
 
-extern vector<JSMButton> grid_mappings;
 extern vector<JSMButton> mappings;
 
-void ScrollAxis::init(DigitalButton& negativeBtn, DigitalButton& positiveBtn, int touchpadId)
+void ScrollAxis::init(DigitalButton& negativeBtn, DigitalButton& positiveBtn, int touchpadId, int leftTrackpadId, int rightTrackpadId)
 {
 	_negativeButton = &negativeBtn;
 	_positiveButton = &positiveBtn;
 	_touchpadId = touchpadId;
+	_leftTrackpadId = leftTrackpadId;
+	_rightTrackpadId = rightTrackpadId;
 }
 
 void ScrollAxis::processScroll(float distance, float sens, chrono::steady_clock::time_point now)
@@ -103,3 +104,26 @@ TouchStick::TouchStick(int index, shared_ptr<DigitalButton::Context> common, int
 	buttons.emplace(ButtonID::TRING, DigitalButton(common, mappings[int(ButtonID::TRING)]));
 }
 
+LeftTouchStick::LeftTouchStick(int index, shared_ptr<DigitalButton::Context> common, int handle)
+	: Stick(SettingID::LTP_DEADZONE_INNER, SettingID::ZERO, SettingID::LTP_RING_MODE, SettingID::LTP_STICK_MODE,
+		ButtonID::LTP_RING, ButtonID::LTP_LEFT, ButtonID::LTP_RIGHT, ButtonID::LTP_UP, ButtonID::LTP_DOWN)
+{
+	this->_leftTrackpadIndex = index;
+	buttons.emplace(ButtonID::LTP_UP, DigitalButton(common, mappings[int(ButtonID::LTP_UP)]));
+	buttons.emplace(ButtonID::LTP_DOWN, DigitalButton(common, mappings[int(ButtonID::LTP_DOWN)]));
+	buttons.emplace(ButtonID::LTP_LEFT, DigitalButton(common, mappings[int(ButtonID::LTP_LEFT)]));
+	buttons.emplace(ButtonID::LTP_RIGHT, DigitalButton(common, mappings[int(ButtonID::LTP_RIGHT)]));
+	buttons.emplace(ButtonID::LTP_RING, DigitalButton(common, mappings[int(ButtonID::LTP_RING)]));
+}
+
+RightTouchStick::RightTouchStick(int index, shared_ptr<DigitalButton::Context> common, int handle)
+	: Stick(SettingID::RTP_DEADZONE_INNER, SettingID::ZERO, SettingID::RTP_RING_MODE, SettingID::RTP_STICK_MODE,
+		ButtonID::RTP_RING, ButtonID::RTP_LEFT, ButtonID::RTP_RIGHT, ButtonID::RTP_UP, ButtonID::RTP_DOWN)
+{
+	this->_rightTrackpadIndex = index;
+	buttons.emplace(ButtonID::RTP_UP, DigitalButton(common, mappings[int(ButtonID::RTP_UP)]));
+	buttons.emplace(ButtonID::RTP_DOWN, DigitalButton(common, mappings[int(ButtonID::RTP_DOWN)]));
+	buttons.emplace(ButtonID::RTP_LEFT, DigitalButton(common, mappings[int(ButtonID::RTP_LEFT)]));
+	buttons.emplace(ButtonID::RTP_RIGHT, DigitalButton(common, mappings[int(ButtonID::RTP_RIGHT)]));
+	buttons.emplace(ButtonID::RTP_RING, DigitalButton(common, mappings[int(ButtonID::RTP_RING)]));
+}

--- a/JoyShockMapper/src/linux/InputHelpers.cpp
+++ b/JoyShockMapper/src/linux/InputHelpers.cpp
@@ -583,8 +583,8 @@ void moveMouse(float x, float y)
 	accumulatedX += x;
 	accumulatedY += y;
 
-	int applicableX = (int)accumulatedX;
-	int applicableY = (int)accumulatedY;
+	int applicableX = lroundf(accumulatedX);
+	int applicableY = lroundf(accumulatedY);
 
 	accumulatedX -= applicableX;
 	accumulatedY -= applicableY;

--- a/JoyShockMapper/src/main.cpp
+++ b/JoyShockMapper/src/main.cpp
@@ -1693,7 +1693,8 @@ void joyShockPollCallback(int jcHandle, JOY_SHOCK_STATE state, JOY_SHOCK_STATE l
 			jc->handleButtonChange(ButtonID::RSR, buttons & (1ULL << JSOFFSET_SR));      // Right back grip button
 			break;
 		case JS_TYPE_STEAM_CONTROLLER_TRITON:
-			// TODO: Left/right grip sense
+			jc->handleButtonChange(ButtonID::LGRIP, buttons & (1ULL << JSOFFSET_LGRIP)); // Left grip sense
+			jc->handleButtonChange(ButtonID::RGRIP, buttons & (1ULL << JSOFFSET_RGRIP)); // Right grip sense
 			// Fall through.
 		case JS_TYPE_STEAM_DECK:
 			jc->handleButtonChange(ButtonID::LSL, buttons & (1ULL << JSOFFSET_SL));                  // L4 back button

--- a/JoyShockMapper/src/main.cpp
+++ b/JoyShockMapper/src/main.cpp
@@ -1484,10 +1484,10 @@ void joyShockPollCallback(int jcHandle, JOY_SHOCK_STATE state, JOY_SHOCK_STATE l
 		case JS_TYPE_FLYDIGI_APEX5:
 			jc->handleButtonChange(ButtonID::LMINI, buttons & (1ULL << JSOFFSET_LMINI)); // LM mini shoulder button
 			jc->handleButtonChange(ButtonID::RMINI, buttons & (1ULL << JSOFFSET_RMINI)); // RM mini shoulder button
-			jc->handleButtonChange(ButtonID::LSL, buttons & (1ULL << JSOFFSET_SL));  // M2 back button (top left)
-			jc->handleButtonChange(ButtonID::RSR, buttons & (1ULL << JSOFFSET_SR));  // M1 back button (top right)
-			jc->handleButtonChange(ButtonID::LSR, buttons & (1ULL << JSOFFSET_FNL)); // M4 back button (bottom left)
-			jc->handleButtonChange(ButtonID::RSL, buttons & (1ULL << JSOFFSET_FNR)); // M3 back button (bottom right)
+			jc->handleButtonChange(ButtonID::LSL, buttons & (1ULL << JSOFFSET_SL));      // M2 back button (top left)
+			jc->handleButtonChange(ButtonID::RSR, buttons & (1ULL << JSOFFSET_SR));      // M1 back button (top right)
+			jc->handleButtonChange(ButtonID::LSR, buttons & (1ULL << JSOFFSET_FNL));     // M4 back button (bottom left)
+			jc->handleButtonChange(ButtonID::RSL, buttons & (1ULL << JSOFFSET_FNR));     // M3 back button (bottom right)
 			break;
 		case JS_TYPE_FLYDIGI_VADER5_PRO:
 			jc->handleButtonChange(ButtonID::LMINI, buttons & (1ULL << JSOFFSET_LMINI)); // LM mini shoulder button
@@ -1496,10 +1496,10 @@ void joyShockPollCallback(int jcHandle, JOY_SHOCK_STATE state, JOY_SHOCK_STATE l
 			// Fall through.
 		case JS_TYPE_FLYDIGI_VADER4_PRO:
 		case JS_TYPE_FLYDIGI_VADER3_PRO:
-			jc->handleButtonChange(ButtonID::LSL, buttons & (1ULL << JSOFFSET_SL));  // M2 back button (top left)
-			jc->handleButtonChange(ButtonID::RSR, buttons & (1ULL << JSOFFSET_SR));  // M1 back button (top right)
-			jc->handleButtonChange(ButtonID::LSR, buttons & (1ULL << JSOFFSET_FNL)); // M4 back button (bottom left)
-			jc->handleButtonChange(ButtonID::RSL, buttons & (1ULL << JSOFFSET_FNR)); // M3 back button (bottom right)
+			jc->handleButtonChange(ButtonID::LSL, buttons & (1ULL << JSOFFSET_SL));      // M2 back button (top left)
+			jc->handleButtonChange(ButtonID::RSR, buttons & (1ULL << JSOFFSET_SR));      // M1 back button (top right)
+			jc->handleButtonChange(ButtonID::LSR, buttons & (1ULL << JSOFFSET_FNL));     // M4 back button (bottom left)
+			jc->handleButtonChange(ButtonID::RSL, buttons & (1ULL << JSOFFSET_FNR));     // M3 back button (bottom right)
 			jc->handleButtonChange(ButtonID::MISC1, buttons & (1ULL << JSOFFSET_MISC1)); // C face button
 			jc->handleButtonChange(ButtonID::MISC2, buttons & (1ULL << JSOFFSET_MISC2)); // Z face button
 			break;

--- a/JoyShockMapper/src/main.cpp
+++ b/JoyShockMapper/src/main.cpp
@@ -137,15 +137,15 @@ struct TOUCH_POINT
 			posY = newState->y();
 			if (prevState)
 			{
-				movX = int16_t((newState->x() - prevState->x()) * tpSize.x()); // Relative movement in unit
-				movY = int16_t((newState->y() - prevState->y()) * tpSize.y());
+				movX = (newState->x() - prevState->x()) * tpSize.x(); // Relative movement in unit
+				movY = (newState->y() - prevState->y()) * tpSize.y();
 			}
 		}
 	}
 	float posX = -1.f;
 	float posY = -1.f;
-	short movX = 0;
-	short movY = 0;
+	float movX = 0.f;
+	float movY = 0.f;
 	inline bool isDown()
 	{
 		return posX >= 0.f && posX <= 1.f && posY >= 0.f && posY <= 1.f;

--- a/JoyShockMapper/src/main.cpp
+++ b/JoyShockMapper/src/main.cpp
@@ -41,6 +41,8 @@ unique_ptr<TrayIcon> tray;
 unique_ptr<Whitelister> whitelister;
 
 vector<JSMButton> grid_mappings; // array of virtual _buttons on the touchpad grid
+vector<JSMButton> left_grid_mappings;
+vector<JSMButton> right_grid_mappings;
 vector<JSMButton> mappings;      // array enables use of for each loop and other i/f
 
 float os_mouse_speed = 1.0;
@@ -209,7 +211,7 @@ void touchCallback(int jcHandle, TOUCH_STATE newState, TOUCH_STATE prevState, fl
 
 		static const function<bool(ButtonID)> IS_TOUCH_BUTTON = [](ButtonID id)
 		{
-			return id >= ButtonID::T1;
+			return (id >= FIRST_TOUCH_BUTTON && id <= LAST_TOUCH_BUTTON);
 		};
 
 		for (auto currentlyActive = find_if(js->_context->chordStack.begin(), js->_context->chordStack.end(), IS_TOUCH_BUTTON);
@@ -243,7 +245,7 @@ void touchCallback(int jcHandle, TOUCH_STATE newState, TOUCH_STATE prevState, fl
 
 		for (size_t i = 0; i < grid_mappings.size(); ++i)
 		{
-			auto optId = magic_enum::enum_cast<ButtonID>(int(FIRST_TOUCH_BUTTON + i));
+			auto optId = magic_enum::enum_cast<ButtonID>(int(FIRST_TOUCH_BUTTON) + int(i));
 
 			// JSM can get touch button callbacks before the grid _buttons are setup at startup. Just skip then.
 			if (optId && js->_gridButtons.size() == grid_mappings.size())
@@ -304,6 +306,166 @@ void touchCallback(int jcHandle, TOUCH_STATE newState, TOUCH_STATE prevState, fl
 			optional<FloatXY> p0 = newState.t0Down ? make_optional<FloatXY>(newState.t0X, newState.t0Y) : nullopt;
 			optional<FloatXY> p1 = newState.t1Down ? make_optional<FloatXY>(newState.t1X, newState.t1Y) : nullopt;
 			js->_context->_vigemController->setTouchState(p0, p1);
+		}
+	}
+}
+
+static void trackpadCallback(int jcHandle, const trackpad_state_t *state, const trackpad_state_t *prev_state, float delta_time)
+{
+	// If there's only one trackpad, treat it as a single touchpad and return.
+	if (state[0].enabled && !state[1].enabled)
+	{
+		TOUCH_STATE newState, prevState;
+		memset(&newState, 0, sizeof(newState));
+		memset(&prevState, 0, sizeof(prevState));
+
+		TOUCH_STATE *touch_states[] = {&newState, &prevState};
+		const trackpad_state_t *states[] = {&state[0], &prev_state[0]};
+
+		for (int i = 0; i < 2; i++)
+		{
+			// First finger
+			touch_states[i]->t0Down = states[i]->fingers[0].down;
+			touch_states[i]->t0X = states[i]->fingers[0].x;
+			touch_states[i]->t0Y = states[i]->fingers[0].y;
+
+			// Second finger
+			touch_states[i]->t1Down = states[i]->fingers[1].down;
+			touch_states[i]->t1X = states[i]->fingers[1].x;
+			touch_states[i]->t1Y = states[i]->fingers[1].y;
+		}
+
+		touchCallback(jcHandle, newState, prevState, delta_time);
+		return;
+	}
+
+	if (!state[0].enabled || !state[1].enabled)
+	{
+		// Shouldn't be here!
+		return;
+	}
+
+	shared_ptr<JoyShock> js;
+	{
+		std::lock_guard<std::mutex> guard(handle_to_joyshock_mutex);
+		js = handle_to_joyshock[jcHandle];
+	}
+
+	int tpSizeX, tpSizeY;
+	if (!js || jsl->GetTouchpadDimension(jcHandle, tpSizeX, tpSizeY) == false)
+	{
+		return;
+	}
+	FloatXY tpSize{ float(tpSizeX), float(tpSizeY) };
+
+	lock_guard guard(js->_context->callback_lock);
+
+	// Always check if the chords should be cleared.
+	for (int i = 0; i < 2; i++)
+	{
+		const finger_state_t *finger = &state[i].fingers[0];
+		const finger_state_t *prev_finger = &prev_state[i].fingers[0];
+
+		TOUCH_POINT point(
+		  finger->down ? make_optional<FloatXY>(finger->x, finger->y) : nullopt,
+		  prev_finger->down ? make_optional<FloatXY>(prev_finger->x, prev_finger->y) : nullopt,
+		  tpSize);
+
+		// If finger was lifted from this trackpad, clear all chords.
+		if (!point.isDown())
+		{
+			// Only clear the range associated with this trackpad.
+			const ButtonID grid_start = state[i].grid_start;
+			const ButtonID grid_end = state[i].grid_end;
+			static const function<bool(ButtonID)> IS_TOUCH_BUTTON = [grid_start, grid_end](ButtonID id)
+			{
+				return (id >= grid_start && id <= grid_end);
+			};
+
+			for (auto currentlyActive = find_if(js->_context->chordStack.begin(), js->_context->chordStack.end(), IS_TOUCH_BUTTON);
+				currentlyActive != js->_context->chordStack.end();
+				currentlyActive = find_if(js->_context->chordStack.begin(), js->_context->chordStack.end(), IS_TOUCH_BUTTON))
+			{
+				js->_context->chordStack.erase(currentlyActive);
+			}
+		}
+	}
+
+	// If both trackpads are simulating a single PS touchpad, handle it now and return.
+	if (js->getSetting<TouchpadMode>(state[0].mode) == TouchpadMode::PS_TOUCHPAD &&
+	    js->getSetting<TouchpadMode>(state[1].mode) == TouchpadMode::PS_TOUCHPAD)
+	{
+		if (js->hasVirtualController())
+		{
+			const finger_state_t *finger0 = &state[0].fingers[0];
+			const finger_state_t *finger1 = &state[1].fingers[0];
+
+			optional<FloatXY> p0 = finger0->down ? make_optional<FloatXY>(finger0->x, finger0->y) : nullopt;
+			optional<FloatXY> p1 = finger1->down ? make_optional<FloatXY>(finger1->x, finger1->y) : nullopt;
+
+			js->_context->_vigemController->setTouchState(p0, p1);
+		}
+
+		return;
+	}
+
+	// If we made it this far, then the trackpads behave independently.
+	const size_t grid_mappings_size[2] = {left_grid_mappings.size(), right_grid_mappings.size()};
+	const size_t grid_buttons_size[2] = {js->_leftGridButtons.size(), js->_rightGridButtons.size()};
+	for (int i = 0; i < 2; i++)
+	{
+		const finger_state_t *finger = &state[i].fingers[0];
+		const finger_state_t *prev_finger = &prev_state[i].fingers[0];
+
+		TOUCH_POINT point(
+		  finger->down ? make_optional<FloatXY>(finger->x, finger->y) : nullopt,
+		  prev_finger->down ? make_optional<FloatXY>(prev_finger->x, prev_finger->y) : nullopt,
+		  tpSize);
+
+		const trackpad_state_t *current_state = &state[i];
+		const TouchpadMode trackpad_mode = js->getSetting<TouchpadMode>(current_state->mode);
+		if (trackpad_mode == TouchpadMode::GRID_AND_STICK)
+		{
+			// Handle grid
+			int index = -1;
+			if (point.isDown())
+			{
+				auto &grid_size = *SettingsManager::getV<FloatXY>(current_state->grid_size);
+				point.posY += 1e-6f;
+				float row = ceilf(point.posY * grid_size.value().y()) - 1.f;
+				float col = ceilf(point.posX * grid_size.value().x()) - 1.f;
+				index = int(row * grid_size.value().x() + col);
+			}
+
+			for (size_t j = 0; j < grid_mappings_size[i]; j++)
+			{
+				const int grid_button = int(state[i].grid_start) + int(j);
+				auto optId = magic_enum::enum_cast<ButtonID>(grid_button);
+
+				// JSM can get touch button callbacks before the grid _buttons are setup at startup. Just skip then.
+				if (optId && grid_buttons_size[i] == grid_mappings_size[i])
+				{
+					js->handleButtonChange(*optId, j == index);
+				}
+			}
+
+			// Handle stick
+			if (i == 0)
+			{
+				js->handleLeftTouchStickChange(js->_leftTrackpads[0], point.isDown(), point.movX, point.movY, delta_time);
+			}
+			else
+			{
+				js->handleRightTouchStickChange(js->_rightTrackpads[0], point.isDown(), point.movX, point.movY, delta_time);
+			}
+		}
+		else if (trackpad_mode == TouchpadMode::MOUSE)
+		{
+			if (point.isDown())
+			{
+				const FloatXY sens = js->getSetting<FloatXY>(current_state->mouse_sens);
+				moveMouse(point.movX * sens.x(), point.movY * sens.y());
+			}
 		}
 	}
 }
@@ -425,6 +587,32 @@ void calibrateTriggers(shared_ptr<JoyShock> jc)
 		break;
 	}
 	jsl->SetTriggerEffect(jc->_handle, jc->_leftEffect, jc->_rightEffect);
+}
+
+static float GetTrackpadTrigger(shared_ptr<JoyShock> jc, uint64_t buttons, bool left_trackpad)
+{
+	if (buttons & (1ULL << (left_trackpad ? JSOFFSET_LTP_CAPTURE : JSOFFSET_RTP_CAPTURE)))
+	{
+		return 1.0f;
+	}
+	else if (jsl->GetTouchDown(jc->_handle, (left_trackpad ? 0 : 1), 0))
+	{
+		return 0.99f;
+	}
+	return 0.0f;
+}
+
+static float GetTouchpadTrigger(shared_ptr<JoyShock> jc, uint64_t buttons)
+{
+	if (buttons & (1ULL << JSOFFSET_CAPTURE))
+	{
+		return 1.0f;
+	}
+	else if (jsl->GetTouchDown(jc->_handle, 0, 0) || jsl->GetTouchDown(jc->_handle, 0, 1))
+	{
+		return 0.99f;
+	}
+	return 0.0f;
 }
 
 void joyShockPollCallback(int jcHandle, JOY_SHOCK_STATE state, JOY_SHOCK_STATE lastState, IMU_STATE imuState, IMU_STATE lastImuState, float deltaTime)
@@ -1400,7 +1588,6 @@ void joyShockPollCallback(int jcHandle, JOY_SHOCK_STATE state, JOY_SHOCK_STATE l
 		float lTrigger = jsl->GetLeftTrigger(jc->_handle);
 		jc->handleTriggerChange(ButtonID::ZL, ButtonID::ZLF, jc->getSetting<TriggerMode>(SettingID::ZL_MODE), lTrigger, jc->_leftEffect);
 
-		bool touch = jsl->GetTouchDown(jc->_handle, false) || jsl->GetTouchDown(jc->_handle, true);
 		switch (jc->_controllerType)
 		{
 		case JS_TYPE_DS:
@@ -1415,13 +1602,11 @@ void joyShockPollCallback(int jcHandle, JOY_SHOCK_STATE state, JOY_SHOCK_STATE l
 			jc->handleButtonChange(ButtonID::MIC, buttons & (1ULL << JSOFFSET_MIC));
 			// Don't break but continue onto DS4 stuff too
 		case JS_TYPE_DS4:
-		{
-			float triggerpos = buttons & (1ULL << JSOFFSET_CAPTURE) ? 1.f :
-			  touch                                              ? 0.99f :
-			                                                       0.f;
-			jc->handleTriggerChange(ButtonID::TOUCH, ButtonID::CAPTURE, jc->getSetting<TriggerMode>(SettingID::TOUCHPAD_DUAL_STAGE_MODE), triggerpos, jc->_unusedEffect);
-		}
-		break;
+			{
+				const float triggerpos = GetTouchpadTrigger(jc, buttons);
+				jc->handleTriggerChange(ButtonID::TOUCH, ButtonID::CAPTURE, jc->getSetting<TriggerMode>(SettingID::TOUCHPAD_DUAL_STAGE_MODE), triggerpos, jc->_unusedEffect);
+			}
+			break;
 		case JS_TYPE_XBOXONE_ELITE:
 			jc->handleButtonChange(ButtonID::LSL, buttons & (1ULL << JSOFFSET_SL)); // Xbox Elite back paddles
 			jc->handleButtonChange(ButtonID::RSR, buttons & (1ULL << JSOFFSET_SR));
@@ -1450,8 +1635,9 @@ void joyShockPollCallback(int jcHandle, JOY_SHOCK_STATE state, JOY_SHOCK_STATE l
 			jc->handleButtonChange(ButtonID::RSR, buttons & (1ULL << JSOFFSET_SR));        // R4 back button
 			jc->handleButtonChange(ButtonID::LSR, buttons & (1ULL << JSOFFSET_FNL));       // M1 button below left stick
 			jc->handleButtonChange(ButtonID::RSL, buttons & (1ULL << JSOFFSET_FNR));       // M2 button below right stick
-			jc->handleButtonChange(ButtonID::LTOUCH, buttons & (1ULL << JSOFFSET_LTOUCH)); // Left stick capacitive touch
-			jc->handleButtonChange(ButtonID::RTOUCH, buttons & (1ULL << JSOFFSET_RTOUCH)); // Right stick capacitive touch
+			// TODO: Left/right capacitive touch sticks
+			//jc->handleButtonChange(ButtonID::LTOUCH, buttons & (1ULL << JSOFFSET_LTOUCH)); // Left stick capacitive touch
+			//jc->handleButtonChange(ButtonID::RTOUCH, buttons & (1ULL << JSOFFSET_RTOUCH)); // Right stick capacitive touch
 			jc->handleButtonChange(ButtonID::MISC1, buttons & (1ULL << JSOFFSET_MISC1));   // QAM button ("..." button)
 			break;
 		case JS_TYPE_G7_PRO_8K:
@@ -1502,6 +1688,30 @@ void joyShockPollCallback(int jcHandle, JOY_SHOCK_STATE state, JOY_SHOCK_STATE l
 			jc->handleButtonChange(ButtonID::RSL, buttons & (1ULL << JSOFFSET_FNR));     // M3 back button (bottom right)
 			jc->handleButtonChange(ButtonID::MISC1, buttons & (1ULL << JSOFFSET_MISC1)); // C face button
 			jc->handleButtonChange(ButtonID::MISC2, buttons & (1ULL << JSOFFSET_MISC2)); // Z face button
+			break;
+		case JS_TYPE_STEAM_CONTROLLER:
+			jc->handleButtonChange(ButtonID::LSL, buttons & (1ULL << JSOFFSET_SL));      // Left back grip button
+			jc->handleButtonChange(ButtonID::RSR, buttons & (1ULL << JSOFFSET_SR));      // Right back grip button
+			break;
+		case JS_TYPE_STEAM_CONTROLLER_TRITON:
+			// TODO: Left/right grip sense
+			// Fall through.
+		case JS_TYPE_STEAM_DECK:
+			// TODO: Left/right capacitive touch sticks
+			jc->handleButtonChange(ButtonID::LSL, buttons & (1ULL << JSOFFSET_SL));                  // L4 back button
+			jc->handleButtonChange(ButtonID::RSR, buttons & (1ULL << JSOFFSET_SR));                  // R4 back button
+			jc->handleButtonChange(ButtonID::LSR, buttons & (1ULL << JSOFFSET_FNL));                 // L5 back button
+			jc->handleButtonChange(ButtonID::RSL, buttons & (1ULL << JSOFFSET_FNR));                 // R5 back button
+			jc->handleButtonChange(ButtonID::MISC1, buttons & (1ULL << JSOFFSET_MISC1));             // QAM button ("..." button)
+			jc->handleButtonChange(ButtonID::LTP_CAPTURE, buttons & (1ULL << JSOFFSET_LTP_CAPTURE)); // Left trackpad click
+			jc->handleButtonChange(ButtonID::RTP_CAPTURE, buttons & (1ULL << JSOFFSET_RTP_CAPTURE)); // Right trackpad click
+			// Left/right trackpad touch triggers
+			{
+				const float left_triggerpos = GetTrackpadTrigger(jc, buttons, true);
+				jc->handleTriggerChange(ButtonID::LTP_TOUCH, ButtonID::LTP_CAPTURE, jc->getSetting<TriggerMode>(SettingID::LTP_DUAL_STAGE_MODE), left_triggerpos, jc->_unusedEffect);
+				const float right_triggerpos = GetTrackpadTrigger(jc, buttons, false);
+				jc->handleTriggerChange(ButtonID::RTP_TOUCH, ButtonID::RTP_CAPTURE, jc->getSetting<TriggerMode>(SettingID::RTP_DUAL_STAGE_MODE), right_triggerpos, jc->_unusedEffect);
+			}
 			break;
 		default:
 			jc->handleButtonChange(ButtonID::LSL, buttons & (1ULL << JSOFFSET_SL));
@@ -1679,11 +1889,30 @@ void connectDevices(bool mergeJoycons = true)
 	// }
 }
 
+static JSMButton *getMapping(ButtonID id)
+{
+	if (int(id) < mappings.size())
+	{
+		return &mappings[int(id)];
+	}
+	else if (id >= FIRST_RTP_BUTTON && int(id) - int(FIRST_RTP_BUTTON) < right_grid_mappings.size())
+	{
+		return &right_grid_mappings[int(id) - int(FIRST_RTP_BUTTON)];
+	}
+	else if (id >= FIRST_LTP_BUTTON && int(id) - int(FIRST_LTP_BUTTON) < left_grid_mappings.size())
+	{
+		return &left_grid_mappings[int(id) - int(FIRST_LTP_BUTTON)];
+	}
+	else if (id >= FIRST_TOUCH_BUTTON && int(id) - int(FIRST_TOUCH_BUTTON) < grid_mappings.size())
+	{
+		return &grid_mappings[int(id) - int(FIRST_TOUCH_BUTTON)];
+	}
+	return nullptr;
+}
+
 void updateSimPressPartner(ButtonID sim, ButtonID origin, const Mapping &newVal)
 {
-	JSMButton *button = int(sim) < mappings.size() ? &mappings[int(sim)] :
-	  int(sim) - FIRST_TOUCH_BUTTON < grid_mappings.size() ? &grid_mappings[int(sim) - FIRST_TOUCH_BUTTON] :
-	                                                      nullptr;
+	JSMButton *button = getMapping(sim);
 	if (button)
 		button->atSimPress(origin)->set(newVal);
 	else
@@ -1692,9 +1921,7 @@ void updateSimPressPartner(ButtonID sim, ButtonID origin, const Mapping &newVal)
 
 void updateDiagPressPartner(ButtonID diag, ButtonID origin, const Mapping &newVal)
 {
-	JSMButton *button = int(diag) < mappings.size()         ? &mappings[int(diag)] :
-	  int(diag) - FIRST_TOUCH_BUTTON < grid_mappings.size() ? &grid_mappings[int(diag) - FIRST_TOUCH_BUTTON] :
-	                                                         nullptr;
+	JSMButton *button = getMapping(diag);
 	if (button)
 		button->atDiagPress(origin)->set(newVal);
 	else
@@ -1739,6 +1966,8 @@ bool do_RESET_MAPPINGS(CmdRegistry *registry)
 	// TODO: make sure omitted settings don't get reset
 	SettingsManager::resetAllSettings();
 	ranges::for_each(grid_mappings, callReset);
+	ranges::for_each(left_grid_mappings, callReset);
+	ranges::for_each(right_grid_mappings, callReset);
 
 	os_mouse_speed = 1.0f;
 	last_flick_and_rotation = 0.0f;
@@ -1786,6 +2015,7 @@ bool do_RECONNECT_CONTROLLERS(string_view arguments, std::function<void()> loadO
 	connectDevices(mergeJoycons);
 	jsl->SetCallback(&joyShockPollCallback);
 	jsl->SetTouchCallback(&touchCallback);
+	jsl->SetTrackpadCallback(&trackpadCallback);
 
 	if (loadOnReconnect)
 		loadOnReconnect();
@@ -2197,6 +2427,26 @@ TriggerMode filterTouchpadDualStageMode(TriggerMode current, TriggerMode next)
 	return next;
 }
 
+TriggerMode filterLeftTrackpadDualStageMode(TriggerMode current, TriggerMode next)
+{
+	if (next == TriggerMode::X_LT || next == TriggerMode::X_RT || next == TriggerMode::INVALID)
+	{
+		COUT_WARN << SettingID::LTP_DUAL_STAGE_MODE << " doesn't support vigem analog modes.\n";
+		return current;
+	}
+	return next;
+}
+
+TriggerMode filterRightTrackpadDualStageMode(TriggerMode current, TriggerMode next)
+{
+	if (next == TriggerMode::X_LT || next == TriggerMode::X_RT || next == TriggerMode::INVALID)
+	{
+		COUT_WARN << SettingID::RTP_DUAL_STAGE_MODE << " doesn't support vigem analog modes.\n";
+		return current;
+	}
+	return next;
+}
+
 StickMode filterMotionStickMode(StickMode current, StickMode next)
 {
 	auto virtual_controller = SettingsManager::getV<ControllerScheme>(SettingID::VIRTUAL_CONTROLLER);
@@ -2320,16 +2570,16 @@ void refreshAutoLoadHelp(JSMAssignment<Switch> *autoloadCmd)
 	autoloadCmd->setHelp(ss.str());
 }
 
-void onNewGridDimensions(CmdRegistry *registry, const FloatXY &newGridDims)
+static void onNewGridDimensionsEx(CmdRegistry *registry, const FloatXY &newGridDims, vector<JSMButton> &in_grid_mappings, ButtonID grid_start)
 {
 	_ASSERT_EXPR(registry, U("You forgot to bind the command registry properly!"));
 	auto numberOfButtons = size_t(newGridDims.first * newGridDims.second);
 
-	if (numberOfButtons < grid_mappings.size())
+	if (numberOfButtons < in_grid_mappings.size())
 	{
 		// Remove all extra touch button commands
 		bool successfulRemove = true;
-		for (auto id = FIRST_TOUCH_BUTTON + numberOfButtons; successfulRemove; ++id)
+		for (auto id = int(grid_start) + numberOfButtons; successfulRemove; ++id)
 		{
 			string name(magic_enum::enum_name(*magic_enum::enum_cast<ButtonID>(id)));
 			successfulRemove = registry->Remove(name);
@@ -2339,32 +2589,47 @@ void onNewGridDimensions(CmdRegistry *registry, const FloatXY &newGridDims)
 		for (auto &js : handle_to_joyshock)
 		{
 			lock_guard guard(js.second->_context->callback_lock);
-			js.second->updateGridSize();
+			js.second->updateGridSize(grid_start);
 		}
 
 		// Remove extra touch button variables
-		while (grid_mappings.size() > numberOfButtons)
-			grid_mappings.pop_back();
+		while (in_grid_mappings.size() > numberOfButtons)
+			in_grid_mappings.pop_back();
 	}
-	else if (numberOfButtons > grid_mappings.size())
+	else if (numberOfButtons > in_grid_mappings.size())
 	{
 		// Add new touch button variables and commands
-		for (int id = FIRST_TOUCH_BUTTON + int(grid_mappings.size()); grid_mappings.size() < numberOfButtons; ++id)
+		for (int id = int(grid_start) + int(in_grid_mappings.size()); in_grid_mappings.size() < numberOfButtons; ++id)
 		{
 			JSMButton touchButton(*magic_enum::enum_cast<ButtonID>(id), Mapping::NO_MAPPING);
 			touchButton.setFilter(&filterMapping);
-			grid_mappings.push_back(touchButton);
-			registry->add(new JSMAssignment<Mapping>(grid_mappings.back()));
+			in_grid_mappings.push_back(touchButton);
+			registry->add(new JSMAssignment<Mapping>(in_grid_mappings.back()));
 		}
 
 		// For all joyshocks, remove extra touch DigitalButtons
 		for (auto &js : handle_to_joyshock)
 		{
 			lock_guard guard(js.second->_context->callback_lock);
-			js.second->updateGridSize();
+			js.second->updateGridSize(grid_start);
 		}
 	}
 	// Else numbers are the same, possibly just reconfigured
+}
+
+static void onNewGridDimensions(CmdRegistry *registry, const FloatXY &newGridDims)
+{
+	onNewGridDimensionsEx(registry, newGridDims, grid_mappings, FIRST_TOUCH_BUTTON);
+}
+
+static void onNewLeftGridDimensions(CmdRegistry *registry, const FloatXY &newGridDims)
+{
+	onNewGridDimensionsEx(registry, newGridDims, left_grid_mappings, FIRST_LTP_BUTTON);
+}
+
+static void onNewRightGridDimensions(CmdRegistry *registry, const FloatXY &newGridDims)
+{
+	onNewGridDimensionsEx(registry, newGridDims, right_grid_mappings, FIRST_RTP_BUTTON);
 }
 
 void onNewStickAxis(AxisMode newAxisMode, bool isVertical)
@@ -2811,7 +3076,19 @@ void initJsmSettings(CmdRegistry *commandRegistry)
 	touch_stick_axis->setFilter(&filterSignPair);
 	SettingsManager::add(touch_stick_axis);
 	commandRegistry->add((new JSMAssignment<AxisSignPair>(*touch_stick_axis))
-	                       ->setHelp("When in AIM mode, set stick X axis inversion. Valid values are the following:\nSTANDARD or 1, and INVERTED or -1"));
+	                       ->setHelp("When in AIM mode, set touchpad touchstick axis inversion. Valid values are the following:\nSTANDARD or 1, and INVERTED or -1"));
+
+	auto ltp_stick_axis = new JSMSetting<AxisSignPair>(SettingID::LTP_STICK_AXIS, { AxisMode::STANDARD, AxisMode::STANDARD });
+	ltp_stick_axis->setFilter(&filterSignPair);
+	SettingsManager::add(ltp_stick_axis);
+	commandRegistry->add((new JSMAssignment<AxisSignPair>(*ltp_stick_axis))
+	                       ->setHelp("When in AIM mode, set left trackpad touchstick axis inversion. Valid values are the following:\nSTANDARD or 1, and INVERTED or -1"));
+
+	auto rtp_stick_axis = new JSMSetting<AxisSignPair>(SettingID::RTP_STICK_AXIS, { AxisMode::STANDARD, AxisMode::STANDARD });
+	rtp_stick_axis->setFilter(&filterSignPair);
+	SettingsManager::add(rtp_stick_axis);
+	commandRegistry->add((new JSMAssignment<AxisSignPair>(*rtp_stick_axis))
+	                       ->setHelp("When in AIM mode, set right trackpad touchstick axis inversion. Valid values are the following:\nSTANDARD or 1, and INVERTED or -1"));
 
 	// Legacy command
 	auto aim_x_sign = new JSMSetting<AxisMode>(SettingID::STICK_AXIS_X, AxisMode::STANDARD);
@@ -3121,7 +3398,29 @@ void initJsmSettings(CmdRegistry *commandRegistry)
 	grid_size->addOnChangeListener(bind(&onNewGridDimensions, commandRegistry, placeholders::_1), true); // Call the listener now
 	SettingsManager::add(SettingID::GRID_SIZE, grid_size);
 	commandRegistry->add((new JSMAssignment<FloatXY>("GRID_SIZE", *grid_size))
-	                       ->setHelp("When TOUCHPAD_MODE is set to GRID_AND_STICK, this variable sets the number of rows and columns in the grid. The product of the two numbers need to be between 1 and 25."));
+	                       ->setHelp("When TOUCHPAD_MODE is set to GRID_AND_STICK, this variable sets the number of rows and columns in the grid. The product of the two numbers needs to be between 1 and 25."));
+
+	auto ltp_grid_size = new JSMVariable(FloatXY{ 2.f, 1.f });
+	ltp_grid_size->setFilter([](auto current, auto next)
+	  {
+		float floorX = floorf(next.x());
+		float floorY = floorf(next.y());
+		return floorX * floorY >= 1 && floorX * floorY <= 25 ? FloatXY{ floorX, floorY } : current; });
+	ltp_grid_size->addOnChangeListener(bind(&onNewLeftGridDimensions, commandRegistry, placeholders::_1), true); // Call the listener now
+	SettingsManager::add(SettingID::LTP_GRID_SIZE, ltp_grid_size);
+	commandRegistry->add((new JSMAssignment<FloatXY>("LTP_GRID_SIZE", *ltp_grid_size))
+	                       ->setHelp("When LTP_MODE is set to GRID_AND_STICK, this variable sets the number of rows and columns in the grid. The product of the two numbers needs to be between 1 and 25."));
+
+	auto rtp_grid_size = new JSMVariable(FloatXY{ 2.f, 1.f });
+	rtp_grid_size->setFilter([](auto current, auto next)
+	  {
+		float floorX = floorf(next.x());
+		float floorY = floorf(next.y());
+		return floorX * floorY >= 1 && floorX * floorY <= 25 ? FloatXY{ floorX, floorY } : current; });
+	rtp_grid_size->addOnChangeListener(bind(&onNewRightGridDimensions, commandRegistry, placeholders::_1), true); // Call the listener now
+	SettingsManager::add(SettingID::RTP_GRID_SIZE, rtp_grid_size);
+	commandRegistry->add((new JSMAssignment<FloatXY>("RTP_GRID_SIZE", *rtp_grid_size))
+	                       ->setHelp("When RTP_MODE is set to GRID_AND_STICK, this variable sets the number of rows and columns in the grid. The product of the two numbers needs to be between 1 and 25."));
 
 	auto touchpad_mode = new JSMSetting<TouchpadMode>(SettingID::TOUCHPAD_MODE, TouchpadMode::GRID_AND_STICK);
 	touchpad_mode->setFilter(&filterInvalidValue<TouchpadMode, TouchpadMode::INVALID>);
@@ -3129,36 +3428,110 @@ void initJsmSettings(CmdRegistry *commandRegistry)
 	commandRegistry->add((new JSMAssignment<TouchpadMode>("TOUCHPAD_MODE", *touchpad_mode))
 	                       ->setHelp("Assign a mode to the touchpad. Valid values are GRID_AND_STICK or MOUSE."));
 
+	auto ltp_mode = new JSMSetting<TouchpadMode>(SettingID::LTP_MODE, TouchpadMode::GRID_AND_STICK);
+	ltp_mode->setFilter(&filterInvalidValue<TouchpadMode, TouchpadMode::INVALID>);
+	SettingsManager::add(ltp_mode);
+	commandRegistry->add((new JSMAssignment<TouchpadMode>("LTP_MODE", *ltp_mode))
+	                       ->setHelp("Assign a mode to the left trackpad. Valid values are GRID_AND_STICK or MOUSE."));
+
+	auto rtp_mode = new JSMSetting<TouchpadMode>(SettingID::RTP_MODE, TouchpadMode::GRID_AND_STICK);
+	rtp_mode->setFilter(&filterInvalidValue<TouchpadMode, TouchpadMode::INVALID>);
+	SettingsManager::add(rtp_mode);
+	commandRegistry->add((new JSMAssignment<TouchpadMode>("RTP_MODE", *rtp_mode))
+	                       ->setHelp("Assign a mode to the right trackpad. Valid values are GRID_AND_STICK or MOUSE."));
+
 	auto touch_ring_mode = new JSMSetting<RingMode>(SettingID::TOUCH_RING_MODE, RingMode::OUTER);
 	touch_ring_mode->setFilter(&filterInvalidValue<RingMode, RingMode::INVALID>);
 	SettingsManager::add(touch_ring_mode);
 	commandRegistry->add((new JSMAssignment<RingMode>(*touch_ring_mode))
-	                       ->setHelp("Sets the ring mode for the touch stick. Valid values are INNER and OUTER"));
+	                       ->setHelp("Sets the ring mode for the touchpad touchstick. Valid values are INNER and OUTER"));
 
 	auto touch_stick_mode = new JSMSetting<StickMode>(SettingID::TOUCH_STICK_MODE, StickMode::NO_MOUSE);
 	touch_stick_mode->setFilter(&filterInvalidValue<StickMode, StickMode::INVALID>)->addOnChangeListener(bind(&updateRingModeFromStickMode, touch_ring_mode, ::placeholders::_1));
 	SettingsManager::add(touch_stick_mode);
 	commandRegistry->add((new JSMAssignment<StickMode>(*touch_stick_mode))
-	                       ->setHelp("Set a mouse mode for the touchpad stick. Valid values are the following:\nNO_MOUSE, AIM, FLICK, FLICK_ONLY, ROTATE_ONLY, MOUSE_RING, MOUSE_AREA, OUTER_RING, INNER_RING"));
+	                       ->setHelp("Set a mouse mode for the touchpad touchstick. Valid values are the following:\nNO_MOUSE, AIM, FLICK, FLICK_ONLY, ROTATE_ONLY, MOUSE_RING, MOUSE_AREA, OUTER_RING, INNER_RING"));
+
+	auto ltp_stick_ring_mode = new JSMSetting<RingMode>(SettingID::LTP_RING_MODE, RingMode::OUTER);
+	ltp_stick_ring_mode->setFilter(&filterInvalidValue<RingMode, RingMode::INVALID>);
+	SettingsManager::add(ltp_stick_ring_mode);
+	commandRegistry->add((new JSMAssignment<RingMode>(*ltp_stick_ring_mode))
+	                       ->setHelp("Sets the ring mode for the left trackpad touchstick. Valid values are INNER and OUTER"));
+
+	auto ltp_stick_mode = new JSMSetting<StickMode>(SettingID::LTP_STICK_MODE, StickMode::NO_MOUSE);
+	ltp_stick_mode->setFilter(&filterInvalidValue<StickMode, StickMode::INVALID>)->addOnChangeListener(bind(&updateRingModeFromStickMode, ltp_stick_ring_mode, ::placeholders::_1));
+	SettingsManager::add(ltp_stick_mode);
+	commandRegistry->add((new JSMAssignment<StickMode>(*ltp_stick_mode))
+	                       ->setHelp("Set a mouse mode for the left trackpad touchstick. Valid values are the following:\nNO_MOUSE, AIM, FLICK, FLICK_ONLY, ROTATE_ONLY, MOUSE_RING, MOUSE_AREA, OUTER_RING, INNER_RING"));
+
+	auto rtp_stick_ring_mode = new JSMSetting<RingMode>(SettingID::RTP_RING_MODE, RingMode::OUTER);
+	rtp_stick_ring_mode->setFilter(&filterInvalidValue<RingMode, RingMode::INVALID>);
+	SettingsManager::add(rtp_stick_ring_mode);
+	commandRegistry->add((new JSMAssignment<RingMode>(*rtp_stick_ring_mode))
+	                       ->setHelp("Sets the ring mode for the right trackpad touchstick. Valid values are INNER and OUTER"));
+
+	auto rtp_stick_mode = new JSMSetting<StickMode>(SettingID::RTP_STICK_MODE, StickMode::NO_MOUSE);
+	rtp_stick_mode->setFilter(&filterInvalidValue<StickMode, StickMode::INVALID>)->addOnChangeListener(bind(&updateRingModeFromStickMode, rtp_stick_ring_mode, ::placeholders::_1));
+	SettingsManager::add(rtp_stick_mode);
+	commandRegistry->add((new JSMAssignment<StickMode>(*rtp_stick_mode))
+	                       ->setHelp("Set a mouse mode for the right trackpad touchstick. Valid values are the following:\nNO_MOUSE, AIM, FLICK, FLICK_ONLY, ROTATE_ONLY, MOUSE_RING, MOUSE_AREA, OUTER_RING, INNER_RING"));
 
 	auto touch_deadzone_inner = new JSMSetting<float>(SettingID::TOUCH_DEADZONE_INNER, 0.3f);
 	touch_deadzone_inner->setFilter(&filterPositive);
 	SettingsManager::add(touch_deadzone_inner);
 	commandRegistry->add((new JSMAssignment<float>(*touch_deadzone_inner))
-	                       ->setHelp("Sets the radius of the circle in which a touch stick input sends no output."));
+	                       ->setHelp("Sets the radius of the circle in which a touchpad touchstick input sends no output."));
+
+	auto ltp_stick_deadzone_inner = new JSMSetting<float>(SettingID::LTP_DEADZONE_INNER, 0.3f);
+	ltp_stick_deadzone_inner->setFilter(&filterPositive);
+	SettingsManager::add(ltp_stick_deadzone_inner);
+	commandRegistry->add((new JSMAssignment<float>(*ltp_stick_deadzone_inner))
+	                       ->setHelp("Sets the radius of the circle in which a left trackpad touchstick input sends no output."));
+
+	auto rtp_stick_deadzone_inner = new JSMSetting<float>(SettingID::RTP_DEADZONE_INNER, 0.3f);
+	rtp_stick_deadzone_inner->setFilter(&filterPositive);
+	SettingsManager::add(rtp_stick_deadzone_inner);
+	commandRegistry->add((new JSMAssignment<float>(*rtp_stick_deadzone_inner))
+	                       ->setHelp("Sets the radius of the circle in which a right trackpad touchstick input sends no output."));
 
 	auto touch_stick_radius = new JSMSetting<float>(SettingID::TOUCH_STICK_RADIUS, 300.f);
 	touch_stick_radius->setFilter([](auto current, auto next)
 	  { return filterPositive(current, floorf(next)); });
 	SettingsManager::add(touch_stick_radius);
 	commandRegistry->add((new JSMAssignment<float>(*touch_stick_radius))
-	                       ->setHelp("Set the radius of the touchpad stick. The center of the stick is always the first point of contact. Use a very large value (ex: 800) to use it as swipe gesture."));
+	                       ->setHelp("Set the radius of the touchpad touchstick. The center of the stick is always the first point of contact. Use a very large value (ex: 800) to use it as swipe gesture."));
+
+	auto ltp_stick_radius = new JSMSetting<float>(SettingID::LTP_STICK_RADIUS, 300.f);
+	ltp_stick_radius->setFilter([](auto current, auto next)
+	  { return filterPositive(current, floorf(next)); });
+	SettingsManager::add(ltp_stick_radius);
+	commandRegistry->add((new JSMAssignment<float>(*ltp_stick_radius))
+	                       ->setHelp("Set the radius of the left trackpad touchstick. The center of the stick is always the first point of contact. Use a very large value (ex: 800) to use it as swipe gesture."));
+
+	auto rtp_stick_radius = new JSMSetting<float>(SettingID::RTP_STICK_RADIUS, 300.f);
+	rtp_stick_radius->setFilter([](auto current, auto next)
+	  { return filterPositive(current, floorf(next)); });
+	SettingsManager::add(rtp_stick_radius);
+	commandRegistry->add((new JSMAssignment<float>(*rtp_stick_radius))
+	                       ->setHelp("Set the radius of the right trackpad touchstick. The center of the stick is always the first point of contact. Use a very large value (ex: 800) to use it as swipe gesture."));
 
 	auto touchpad_sens = new JSMSetting<FloatXY>(SettingID::TOUCHPAD_SENS, { 1.f, 1.f });
 	touchpad_sens->setFilter(filterFloatPair);
 	SettingsManager::add(touchpad_sens);
 	commandRegistry->add((new JSMAssignment<FloatXY>(*touchpad_sens))
 	                       ->setHelp("Changes the sensitivity of the touchpad when set as a mouse. Enter a second value for a different vertical sensitivity."));
+
+	auto ltp_mouse_sens = new JSMSetting<FloatXY>(SettingID::LTP_SENS, { 1.f, 1.f });
+	ltp_mouse_sens->setFilter(filterFloatPair);
+	SettingsManager::add(ltp_mouse_sens);
+	commandRegistry->add((new JSMAssignment<FloatXY>(*ltp_mouse_sens))
+	                       ->setHelp("Changes the sensitivity of the left trackpad when set as a mouse. Enter a second value for a different vertical sensitivity."));
+
+	auto rtp_mouse_sens = new JSMSetting<FloatXY>(SettingID::RTP_SENS, { 1.f, 1.f });
+	rtp_mouse_sens->setFilter(filterFloatPair);
+	SettingsManager::add(rtp_mouse_sens);
+	commandRegistry->add((new JSMAssignment<FloatXY>(*rtp_mouse_sens))
+	                       ->setHelp("Changes the sensitivity of the right trackpad when set as a mouse. Enter a second value for a different vertical sensitivity."));
 
 	auto hide_minimized = new JSMVariable<Switch>(Switch::OFF);
 	minimizeThread.reset(new PollingThread( "Minimize thread", [] (void *param)
@@ -3188,6 +3561,18 @@ void initJsmSettings(CmdRegistry *commandRegistry)
 	SettingsManager::add(touch_ds_mode);
 	commandRegistry->add((new JSMAssignment<TriggerMode>(*touch_ds_mode))
 	                       ->setHelp("Dual stage mode for the touchpad TOUCH and CAPTURE (i.e. click) bindings."));
+
+	auto ltp_dual_stage_mode = new JSMSetting<TriggerMode>(SettingID::LTP_DUAL_STAGE_MODE, TriggerMode::NO_SKIP);
+	ltp_dual_stage_mode->setFilter(&filterLeftTrackpadDualStageMode);
+	SettingsManager::add(ltp_dual_stage_mode);
+	commandRegistry->add((new JSMAssignment<TriggerMode>(*ltp_dual_stage_mode))
+	                       ->setHelp("Dual stage mode for the left trackpad LTP_TOUCH and LTP_CAPTURE bindings."));
+
+	auto rtp_dual_stage_mode = new JSMSetting<TriggerMode>(SettingID::RTP_DUAL_STAGE_MODE, TriggerMode::NO_SKIP);
+	rtp_dual_stage_mode->setFilter(&filterRightTrackpadDualStageMode);
+	SettingsManager::add(rtp_dual_stage_mode);
+	commandRegistry->add((new JSMAssignment<TriggerMode>(*rtp_dual_stage_mode))
+	                       ->setHelp("Dual stage mode for the right trackpad RTP_TOUCH and RTP_CAPTURE bindings."));
 
 	auto rumble_enable = new JSMVariable<Switch>(Switch::ON);
 	rumble_enable->setFilter(&filterInvalidValue<Switch, Switch::INVALID>);
@@ -3430,7 +3815,9 @@ int main(int argc, char *argv[])
 	jsl.reset(JslWrapper::getNew());
 	whitelister.reset(Whitelister::getNew(false));
 
-	grid_mappings.reserve(int(ButtonID::T25) - FIRST_TOUCH_BUTTON); // This makes sure the items will never get copied and cause crashes
+	grid_mappings.reserve(NUM_TOUCH_BUTTONS); // This makes sure the items will never get copied and cause crashes
+	left_grid_mappings.reserve(NUM_LTP_BUTTONS);
+	right_grid_mappings.reserve(NUM_RTP_BUTTONS);
 	mappings.reserve(MAPPING_SIZE);
 	for (int id = 0; id < MAPPING_SIZE; ++id)
 	{
@@ -3539,6 +3926,7 @@ int main(int argc, char *argv[])
 	connectDevices();
 	jsl->SetCallback(&joyShockPollCallback);
 	jsl->SetTouchCallback(&touchCallback);
+	jsl->SetTrackpadCallback(&trackpadCallback);
 	
 #ifndef _WIN32
 	// On Linux, skip tray icon creation to avoid GTK issues in headless environments

--- a/JoyShockMapper/src/main.cpp
+++ b/JoyShockMapper/src/main.cpp
@@ -1635,10 +1635,9 @@ void joyShockPollCallback(int jcHandle, JOY_SHOCK_STATE state, JOY_SHOCK_STATE l
 			jc->handleButtonChange(ButtonID::RSR, buttons & (1ULL << JSOFFSET_SR));        // R4 back button
 			jc->handleButtonChange(ButtonID::LSR, buttons & (1ULL << JSOFFSET_FNL));       // M1 button below left stick
 			jc->handleButtonChange(ButtonID::RSL, buttons & (1ULL << JSOFFSET_FNR));       // M2 button below right stick
-			// TODO: Left/right capacitive touch sticks
-			//jc->handleButtonChange(ButtonID::LTOUCH, buttons & (1ULL << JSOFFSET_LTOUCH)); // Left stick capacitive touch
-			//jc->handleButtonChange(ButtonID::RTOUCH, buttons & (1ULL << JSOFFSET_RTOUCH)); // Right stick capacitive touch
 			jc->handleButtonChange(ButtonID::MISC1, buttons & (1ULL << JSOFFSET_MISC1));   // QAM button ("..." button)
+			jc->handleButtonChange(ButtonID::LTOUCH, buttons & (1ULL << JSOFFSET_LTOUCH)); // Left stick capacitive touch
+			jc->handleButtonChange(ButtonID::RTOUCH, buttons & (1ULL << JSOFFSET_RTOUCH)); // Right stick capacitive touch
 			break;
 		case JS_TYPE_G7_PRO_8K:
 			jc->handleButtonChange(ButtonID::LMINI, buttons & (1ULL << JSOFFSET_LMINI));     // L5 mini shoulder button
@@ -1697,7 +1696,6 @@ void joyShockPollCallback(int jcHandle, JOY_SHOCK_STATE state, JOY_SHOCK_STATE l
 			// TODO: Left/right grip sense
 			// Fall through.
 		case JS_TYPE_STEAM_DECK:
-			// TODO: Left/right capacitive touch sticks
 			jc->handleButtonChange(ButtonID::LSL, buttons & (1ULL << JSOFFSET_SL));                  // L4 back button
 			jc->handleButtonChange(ButtonID::RSR, buttons & (1ULL << JSOFFSET_SR));                  // R4 back button
 			jc->handleButtonChange(ButtonID::LSR, buttons & (1ULL << JSOFFSET_FNL));                 // L5 back button
@@ -1705,6 +1703,8 @@ void joyShockPollCallback(int jcHandle, JOY_SHOCK_STATE state, JOY_SHOCK_STATE l
 			jc->handleButtonChange(ButtonID::MISC1, buttons & (1ULL << JSOFFSET_MISC1));             // QAM button ("..." button)
 			jc->handleButtonChange(ButtonID::LTP_CAPTURE, buttons & (1ULL << JSOFFSET_LTP_CAPTURE)); // Left trackpad click
 			jc->handleButtonChange(ButtonID::RTP_CAPTURE, buttons & (1ULL << JSOFFSET_RTP_CAPTURE)); // Right trackpad click
+			jc->handleButtonChange(ButtonID::LTOUCH, buttons & (1ULL << JSOFFSET_LTOUCH));           // Left stick capacitive touch
+			jc->handleButtonChange(ButtonID::RTOUCH, buttons & (1ULL << JSOFFSET_RTOUCH));           // Right stick capacitive touch
 			// Left/right trackpad touch triggers
 			{
 				const float left_triggerpos = GetTrackpadTrigger(jc, buttons, true);

--- a/JoyShockMapper/src/win32/InputHelpers.cpp
+++ b/JoyShockMapper/src/win32/InputHelpers.cpp
@@ -148,8 +148,8 @@ void moveMouse(float x, float y)
 	accumulatedX += x;
 	accumulatedY += y;
 
-	int applicableX = (int)accumulatedX;
-	int applicableY = (int)accumulatedY;
+	int applicableX = lroundf(accumulatedX);
+	int applicableY = lroundf(accumulatedY);
 
 	accumulatedX -= applicableX;
 	accumulatedY -= applicableY;


### PR DESCRIPTION
Changes:
- Add support for dual trackpads (Steam Controller, Steam Deck)
    - Matches the feature set of the existing touchpad implementation
    - See JSM docs for details
- Use updated SDL3 capacitive touch stick support (Steam Controller, Steam Deck, Horipad for Steam)
- Add grip sense support (Steam Controller)
- Build with latest snapshot of SDL3 main branch
    - Full support for G7 Pro 8K, Steam Controller, Steam Deck, Horipad for Steam
    - New capsense events
    - Updated mappings
    - Bug fixes
    - Disabled unused subsystems
- Build with libusb (Switch 2 controller support)

Steam Controller trackpads may improve in the future after upstream SDL3 requests are addressed, but they function well currently.

JSM's code is tricky for me to work with, so please forgive some of the naive decisions that were made to wrangle the code into something a little more flexible for two trackpads.

Finally, this PR may be worth a beta release since it's not realistic for me to test every esoteric configuration that users may come up with.