### PR TITLE
Extend LIGHT_BAR to support Switch controllers

### DIFF
--- a/JoyShockMapper/src/SDLWrapper.cpp
+++ b/JoyShockMapper/src/SDLWrapper.cpp
@@ -1070,7 +1070,8 @@ public:
 	{
 		auto prop = SDL_GetGamepadProperties(_controllerMap[deviceId]->_sdlController);
 		
-		if (SDL_GetStringProperty(prop, SDL_PROP_GAMEPAD_CAP_RGB_LED_BOOLEAN, nullptr) != nullptr)
+		if (SDL_GetBooleanProperty(prop, SDL_PROP_GAMEPAD_CAP_RGB_LED_BOOLEAN, false) ||
+		    SDL_GetBooleanProperty(prop, SDL_PROP_GAMEPAD_CAP_MONO_LED_BOOLEAN, false))
 		{
 			union
 			{


### PR DESCRIPTION
A recent update to SDL3 enabled the Home button LED on Switch controllers, which is set to full brightness by default and also drains the battery: https://github.com/libsdl-org/SDL/commit/90dabda3b4ca85715e6108ed4f20310c680f06e5

Any of these will set the LED to full brightness:
```
LIGHT_BAR = 255 255 255
LIGHT_BAR = xFFFFFF
LIGHT_BAR = WHITE
```

For Switch controllers, only the largest value matters, so any of these will also be full brightness:
```
LIGHT_BAR = 0 0 255
LIGHT_BAR = xFF
LIGHT_BAR = BLUE
```

Off:
```
LIGHT_BAR = 0 0 0
LIGHT_BAR = x0
LIGHT_BAR = BLACK
```